### PR TITLE
Add USD Light/Camera/Axis plugins

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,9 +39,10 @@ option(WITH_UNITTESTS "Enable unit test building" OFF)
 
 if (WITH_UNITTESTS)
   find_package(Catch2 REQUIRED)
+  find_package(Qt5 REQUIRED COMPONENTS Core Gui Widgets)
   add_library(CatchTestMain OBJECT CatchTestMain.cpp)
   add_library(Nuke::CatchTestMain ALIAS CatchTestMain)
-  target_link_libraries(CatchTestMain PUBLIC Catch2::Catch2)
+  target_link_libraries(CatchTestMain PUBLIC Qt5::Gui Catch2::Catch2)
 
   function(add_nuke_unittest TARGET_NAME)
     add_executable(${TARGET_NAME} ${ARGN})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2020 Foundry
+# Copyright 2021 Foundry
 #
 # Licensed under the Apache License, Version 2.0 (the "Apache License")
 # with the following modification; you may not use this file except in

--- a/CatchTestMain.cpp
+++ b/CatchTestMain.cpp
@@ -1,4 +1,4 @@
-// Copyright 2020 Foundry
+// Copyright 2021 Foundry
 //
 // Licensed under the Apache License, Version 2.0 (the "Apache License")
 // with the following modification; you may not use this file except in

--- a/Plugin/usdReader.cpp
+++ b/Plugin/usdReader.cpp
@@ -1,4 +1,4 @@
-// Copyright 2020 Foundry
+// Copyright 2021 Foundry
 //
 // Licensed under the Apache License, Version 2.0 (the "Apache License")
 // with the following modification; you may not use this file except in

--- a/Plugin/usdReader.cpp
+++ b/Plugin/usdReader.cpp
@@ -26,10 +26,14 @@
 
 #include "usdReader.h"
 
+#include <fstream>
 #include <DDImage/Application.h>
 #include <DDImage/File_KnobI.h>
 #include <DDImage/NodeI.h>
+#include <DDImage/OpMessageHandler.h>
+#include <DDImage/OpTreeHandler.h>
 #include <DDImage/SceneGraph_KnobI.h>
+#include <pxr/usd/usd/usdFileFormat.h>
 #include <UsdConverter/UsdGeoConverter.h>
 #include <UsdConverter/UsdUI.h>
 
@@ -39,6 +43,9 @@ using namespace DD::Image;
 
 usdReader::usdReader(ReadGeo* geo) : GeoReader(geo)
 {
+  const char * fileName = filename();
+  if(fileName && strlen(fileName) > 0)
+    _fileExists = std::ifstream(filename()).good();
 }
 
 usdReaderFormat* usdReader::getFormat()
@@ -58,7 +65,9 @@ const usdReaderFormat* usdReader::getFormat() const
 SceneGraph_KnobI* usdReader::getSceneGraphKnob()
 {
   Knob* pNodeNameKnob = geo->knob(usdReaderFormat::kNodeKnobName.c_str());
-  assert(pNodeNameKnob);
+  if(!pNodeNameKnob) {
+    return nullptr;
+  }
   return pNodeNameKnob->sceneGraphKnob();
 }
 
@@ -66,23 +75,29 @@ void usdReader::get_geometry_hash(Hash* geo_hash)
 {
   // Rebuild primitives on change of filename, current frame (conditionally) etc.
   append(geo_hash[Group_Primitives]);
+  // The geometry hashes need to be calculated correctly when things change.
+  const auto pfmt = getFormat();
+  if (pfmt->_readOnEachFrame) {
+    geo_hash[Group_Matrix].append(geo->outputContext().frame());
+  }
 }
 
 void usdReader::geometry_engine(Scene&, GeometryList& out)
 {
-  const auto frame = geo->outputContext().frame();
-
-  usdReaderFormat* pfmt = getFormat();
-
-  SceneGraph_KnobI* pSceneGraphKnob = getSceneGraphKnob();
+  const auto pSceneGraphKnob = getSceneGraphKnob();
+  if(!pSceneGraphKnob) {
+    return;
+  }
 
   // Retrieve from scene graph knob which prims the user wants to load
   std::vector<std::string> selectedPaths = pSceneGraphKnob->getSelectedItems();
+  const auto frame = geo->outputContext().frame();
+  const auto pfmt = getFormat();
 
-  // Time at which to load geometry: either Nuke frame or the USD default frame, depending on knob setting
+  // Time at which to load geometry: either Nuke frame or the earliest frame, depending on knob setting
   const pxr::UsdTimeCode time = pfmt->_readOnEachFrame
                                     ? pxr::UsdTimeCode(frame)
-                                    : pxr::UsdTimeCode::Default();
+                                    : pxr::UsdTimeCode::EarliestTime();
 
   if(geo->rebuild(Mask_Primitives)) {
     // Destroy old geometry and retrieve from file at desired time
@@ -94,70 +109,92 @@ void usdReader::geometry_engine(Scene&, GeometryList& out)
 
 int usdReader::knob_changed(Knob* k)
 {
-  const usdReaderFormat* pfmt = getFormat();
+  const auto pSceneGraphKnob = getSceneGraphKnob();
+  if(!pSceneGraphKnob) {
+    return 1;
+  }
+
+  const auto pfmt = getFormat();
+  auto loadSceneGraph = [this, pfmt](SceneGraph_KnobI* sceneKnob, const char* filename,
+                                     bool showBrowser, bool resetSelected) -> bool {
+
+    const bool validFileName = filename && (strlen(filename) > 0);
+    if(validFileName && !_fileExists) {
+      geo->internalError("No such file or directory");
+      sceneKnob->clear();
+      return false;
+    }
+    else if(_fileExists && !Foundry::UsdConverter::GetSceneGraphData(sceneKnob, filename, showBrowser, resetSelected)){
+      geo->internalError("USD file contains no supported data");
+      _validateSceneItems = true;
+      sceneKnob->clear();
+      return false;
+    }
+    if(!resetSelected) {
+      // pfmt probably hasn't stored the value of this knob yet
+      sceneKnob->viewAllNodes(geo->knob(pfmt->kAllObjectsKnobName.c_str())->get_value());
+    }
+
+    return true;
+  };
+
   if(k->is(ReadGeo::kFileKnobName)) {
     // Open USD file and fill scene graph, may open pop up window for prim selection. Empty scene graph on error
     File_KnobI* fileKnobInterface = k->fileKnob();
-    bool resetSelected = fileKnobInterface->getLastChangeContext() ==
-                         File_KnobI::ChangedFromUser;
+    bool resetSelected = fileKnobInterface->getLastChangeContext() == File_KnobI::ChangedFromUser;
     bool showBrowser = Application::IsGUIActive() && resetSelected;
-
+    _validateSceneItems = !showBrowser;
     const char* readGeoFilename = k->get_text(&geo->uiContext());
-    if(readGeoFilename != nullptr && strlen(readGeoFilename) > 0) {
-      if(!Foundry::UsdConverter::GetSceneGraphData(getSceneGraphKnob(),
-                                                   readGeoFilename, showBrowser,
-                                                   resetSelected)) {
-        geo->internalError("No such file or directory or invalid file");
-        getSceneGraphKnob()->clear();
-        return 1;
-      }
+    _fileExists = readGeoFilename && strlen(readGeoFilename) && std::ifstream(readGeoFilename).good();
+    if (!loadSceneGraph(pSceneGraphKnob, readGeoFilename, showBrowser, resetSelected)) {
+      return 1;
     }
     else {
-      SceneGraph_KnobI* pSceneGraphKnob = getSceneGraphKnob();
-      if(pSceneGraphKnob) {
-        pSceneGraphKnob->clear();
-        return 1;
-      }
-    }
-
-    if(!resetSelected) {
-      // pfmt probably hasn't stored the value of this knob yet
-      getSceneGraphKnob()->viewAllNodes(
-          geo->knob(pfmt->kAllObjectsKnobName.c_str())->get_value());
+      forceClearErrors();
     }
   }
   else if(k->is(ReadGeo::kReloadKnobName)) {
     // Reload USD file without popping up scene graph browser window
-    if(!Foundry::UsdConverter::GetSceneGraphData(getSceneGraphKnob(),
-                                                 filename(), false, false)) {
-      geo->internalError("No such file or directory or invalid file");
-      getSceneGraphKnob()->clear();
+    if(!loadSceneGraph(pSceneGraphKnob, filename(), false, false)) {
       return 1;
     }
-    getSceneGraphKnob()->viewAllNodes(
-        geo->knob(pfmt->kAllObjectsKnobName.c_str())->get_value());
   }
-  else if(k->is(DD::Image::kSceneGraphKnobName)) {
+  else if(k->is( DD::Image::kSceneGraphKnobName )) {
     // React to scene graph knob user input
     geo->set_rebuild(Mask_Primitives);
     geo->invalidate();
+    validateItems();
+    _validateSceneItems = true;
   }
   else if(k->is(pfmt->kAllObjectsKnobName.c_str())) {
     // Enable/disable showing all objects in scene graph
-    SceneGraph_KnobI* pSceneGraphKnob = getSceneGraphKnob();
     pSceneGraphKnob->viewAllNodes(pfmt->_allObjects);
     return 1;
   }
-
   return 0;
 }
 
 void usdReader::_validate(const bool /* unused */)
 {
+  if (_fileExists) {
+    const auto pSceneGraphKnob = getSceneGraphKnob();
+    if (_validateSceneItems && pSceneGraphKnob) {
+      validateItems();
+    }
+  }
+  else {
+    const char * fileName = filename();
+    if (fileName && strlen(fileName) > 0)
+      geo->internalError("No such file or directory");
+  }
 }
 
 void usdReader::append(Hash& newHash)
 {
+  const auto pSceneGraphKnob = getSceneGraphKnob();
+  if(!pSceneGraphKnob) {
+    return;
+  }
   const usdReaderFormat* pfmt = getFormat();
 
   // Append current frame to the hash
@@ -173,10 +210,31 @@ void usdReader::append(Hash& newHash)
   newHash.append(pFilename);
 
   // Append all items selected in the scene graph knob to hash
-  SceneGraph_KnobI* pSceneGraphKnob = getSceneGraphKnob();
   const auto selectedNodes = pSceneGraphKnob->getSelectedItems();
   for(const auto& node : selectedNodes) {
     newHash.append(node);
+  }
+}
+
+void usdReader::validateItems()
+{
+  if (getSceneGraphKnob()->isEmpty()) {
+    geo->internalError("USD file contains no supported data");
+  }
+}
+
+void usdReader::forceClearErrors()
+{
+  geo->clearError();
+
+  auto& msgHandler = geo->getMsgHandler();
+  if (msgHandler.hasMessage())
+  {
+    // Clear all existing messages that are from the op itself
+    msgHandler.clearMessagesFromSource(geo, OpMessage::eFromOp, geo->getTreeHandler()->lockTrees());
+    if (!msgHandler.hasMessage())
+      geo->getTreeHandler()->removeMessageOpFromTrees(geo);
+    geo->getTreeHandler()->unlockTrees();
   }
 }
 
@@ -194,10 +252,18 @@ namespace
   }
 
   // Register all USD file types and associate the format object with the custom knobs with them
-  bool is_usd_file(int /* unused */, const unsigned char* /* unused */, int /* unused */)
+  bool is_usd_filename(const std::string& filename)
   {
-    return true;
+    static const std::set<std::string> exts = pxr::SdfFileFormat::FindAllFileFormatExtensions();
+    for(const auto& ext : exts) {
+      auto file_type = pxr::SdfFileFormat::FindByExtension(ext);
+      if(file_type && file_type->CanRead(filename)) {
+        return true;
+      }
+    }
+    return false;
   }
+
   const GeoDescription description("usd\0usda\0usdc\0usdz\0", build_reader,
-                                   build_format, is_usd_file, nullptr, false);
+                                   build_format, is_usd_filename, nullptr, false);
 }  // namespace

--- a/Plugin/usdReader.h
+++ b/Plugin/usdReader.h
@@ -1,4 +1,4 @@
-// Copyright 2020 Foundry
+// Copyright 2021 Foundry
 //
 // Licensed under the Apache License, Version 2.0 (the "Apache License")
 // with the following modification; you may not use this file except in

--- a/Plugin/usdReader.h
+++ b/Plugin/usdReader.h
@@ -36,7 +36,7 @@
 
 #include "DDImage/GeoReader.h"
 #include "DDImage/GeoReaderDescription.h"
-#include "DDImage/SceneView_KnobI.h"
+#include "DDImage/SceneItem.h"
 
 class usdReaderFormat;
 
@@ -69,6 +69,15 @@ class usdReader : public DD::Image::GeoReader
 
   /// Get the scene graph knob for the geo node that the reader is attached to
   DD::Image::SceneGraph_KnobI* getSceneGraphKnob();
+
+  /// Validate scene items and report error if the items are not supported
+  void validateItems();
+
+  ///Clear all errors immediately
+  void forceClearErrors();
+
+  bool _fileExists{ false };
+  bool _validateSceneItems{ false };
 };
 
 #endif  // USDREADER_H

--- a/Plugin/usdReaderFormat.cpp
+++ b/Plugin/usdReaderFormat.cpp
@@ -1,4 +1,4 @@
-// Copyright 2020 Foundry
+// Copyright 2021 Foundry
 //
 // Licensed under the Apache License, Version 2.0 (the "Apache License")
 // with the following modification; you may not use this file except in

--- a/Plugin/usdReaderFormat.cpp
+++ b/Plugin/usdReaderFormat.cpp
@@ -57,7 +57,7 @@ void usdReaderFormat::extraKnobs(Knob_Callback f)
   Tab_knob(f, "Scenegraph");
 
   Knob* pNodeNameKnob =
-      SceneGraph_knob(f, &_nodeNameIndex, &SceneGraph::kDefaultFields,
+      SceneGraph_knob(f, &_nodeNameIndex, nullptr,
                       kNodeKnobName.c_str(), "");
   if(pNodeNameKnob != nullptr) {
     SetFlags(f, Knob::SAVE_MENU | Knob::EARLY_STORE | Knob::ALWAYS_SAVE);

--- a/Plugin/usdReaderFormat.h
+++ b/Plugin/usdReaderFormat.h
@@ -1,4 +1,4 @@
-// Copyright 2020 Foundry
+// Copyright 2021 Foundry
 //
 // Licensed under the Apache License, Version 2.0 (the "Apache License")
 // with the following modification; you may not use this file except in

--- a/README.md
+++ b/README.md
@@ -5,12 +5,14 @@ This project implements a USD reader plugin for Nuke's ReadGeo node.
 ## Building
 The Nuke USD plug-in has the following dependencies:
 - Compiler requirements are as for all Nuke NDK plugins.
-- Nuke (12.2v1 onwards)
-- USD (https://github.com/PixarAnimationStudios/USD/releases/tag/v19.11) (19.11 onwards)
+- Nuke (13.0v1 onwards)
+- USD (https://github.com/PixarAnimationStudios/USD/releases/tag/v21.05) (21.05 onwards)
 - Boost (https://boost.org) (header only, 1.66.0 onwards)
+- OpenSubdiv
+- TBB
 - CMake (https://cmake.org/documentation/) (3.13 onwards)
 - [Recommended build tool] Ninja (https://ninja-build.org/) (1.8.2 onwards)
-- [Only if building with unit tests] Catch2 (https://github.com/catchorg/Catch2)
+- [Only if building with unit tests] Catch2 (https://github.com/catchorg/Catch2) and Qt5
   - The unit tests are disabled by default. Enable them by setting the CMake option WITH_UNITTESTS=ON.
 
 We use the CMake find_package mechanism to set up dependencies.
@@ -22,10 +24,12 @@ Example build command using the Ninja generator:
 
 ```
 cmake \
--G Ninja
+-G Ninja \
 -D Nuke_DIR=<YOUR_NUKE_INSTALL_ROOT> \
 -D pxr_DIR=<PATH_TO_USD_DIRECTORY> \
 -D BOOST_ROOT=<PATH_TO_BOOST_DIRECTORY> \
+-D TBB_DIR=<PATH_TO_TBB_DIRECTORY> \
+-D OpenSubdiv_DIR=<PATH_TO_OPENSUBDIV> \
 -D CMAKE_INSTALL_PREFIX=<YOUR_INSTALL_PREFIX> \
 -D CMAKE_BUILD_TYPE=Release \
 <USD_PLUGIN_SOURCE_DIRECTORY>
@@ -33,16 +37,28 @@ cmake \
 ninja install
 ```
 
-To install, copy the usdReader plugin and the UsdConverter shared library
+Note: for MacOS, the root directory is where the FindNuke.cmake file is - for example: /Applications/Nuke13.1v1/Nuke13.1v1.app/Contents/MacOS .
+
+To install, copy the UsdConverter shared library, the usdReader and the usdSceneReader plugin
 from CMAKE_INSTALL_PREFIX to your .nuke folder.
+
+If the version of USD used by Nuke is different than the version these plugins are compiled with, it's necessary to make sure that the correct
+version of the PXR library is loaded. For example, by replacing the PXR libraries in the Nuke install, setting the library path in the environment
+or setting the rpath in the CMake file.
 
 ## Project structure
 
 ### Plugin subdirectory
 
-This subdirectory contains the usdReader plugin sources, a specialization of the Nuke GeoReader class. The usdReader registers the USD file types so they are recognized by the ReadGeo node and creates knobs for setting loading options like the scene graph for choosing which primitives to load. The plugin does not contain any logic for converting USD geometry to Nuke's internal format. Instead it links to the UsdConverter shared library which encapsulates that functionality.
+This subdirectory contains the usdReader plugin sources, a specialization of the Nuke GeoReader class. The usdReader registers the USD file types 
+so they are recognized by the ReadGeo node and creates knobs for setting loading options like the scene graph for choosing which primitives to load. 
+The plugin does not contain any logic for converting USD geometry to Nuke's internal format. Instead it links to the UsdConverter shared library 
+which encapsulates that functionality.
 
 ### UsdConverter subdirectory
 
-This subdirectory contains the UsdConverter shared library which converts USD to Nuke geometry. The API offers functions at various levels of abstraction, e.g. the usdReader plugin uses the high level function loadUsd() to add the geometry from a USD file into a Nuke GeometryList. It is divided into functions dealing with geometry (Mesh, Points, Cube, PointInstancer), geometry attributes (points, vertices, colors, ...) and scene graph knob initialization. Public API functions are marked wih
-the FN_USDCONVERTER_API export macro, everything else is hidden and used only internally.
+This subdirectory contains the UsdConverter shared library which converts USD to Nuke geometry and the SceneReader plugin which adds plugins for the
+Light, Camera, and Axis nodes. The UsdConverter API offers functions at various levels of abstraction, e.g. the usdReader plugin uses the high level 
+function loadUsd() to add the geometry from a USD file into a Nuke GeometryList. It is divided into functions dealing with geometry (Mesh, Points, 
+Cube, PointInstancer), geometry attributes (points, vertices, colors, ...) and scene graph knob initialization. Public API functions are marked wih 
+the FN_USDCONVERTER_API export macro, everything else is hidden and used only internally. 

--- a/UsdConverter/CMakeLists.txt
+++ b/UsdConverter/CMakeLists.txt
@@ -23,6 +23,7 @@
 #===------------------------------------------------------------------------===
 # Create object library so we can unittest internal functions
 add_library( UsdConverterObjectlib OBJECT
+    src/UsdCommon.cpp
     src/UsdGeoConverter.cpp
     src/UsdAttrConverter.cpp
     src/UsdUI.cpp )
@@ -38,7 +39,7 @@ target_compile_definitions( UsdConverterObjectlib
 
 set_target_properties( UsdConverterObjectlib PROPERTIES POSITION_INDEPENDENT_CODE ON )
 
-if (WIN32)
+if ( WIN32 )
   target_compile_definitions( UsdConverterObjectlib
     PUBLIC
       NOMINMAX )
@@ -69,6 +70,25 @@ target_link_libraries( UsdConverter
 
 install( TARGETS UsdConverter DESTINATION . )
 
-if (WITH_UNITTESTS)
-  add_subdirectory( unit_tests )
+add_nuke_plugin( usdSceneReader
+  src/UsdCommon.cpp
+  src/UsdSceneReader.cpp
+  src/UsdSceneGraphPlugin.cpp
+  src/UsdAxisScenePlugin.cpp
+  src/UsdCameraScenePlugin.cpp
+  src/UsdLightScenePlugin.cpp )
+target_include_directories( usdSceneReader PUBLIC include )
+target_link_libraries(usdSceneReader
+  PRIVATE
+    Nuke::UsdConverter
+    Nuke::NDK
+    usd
+    usdGeom
+    usdLux
+)
+
+install( TARGETS usdSceneReader DESTINATION . )
+
+if ( WITH_UNITTESTS )
+ add_subdirectory( unit_tests )
 endif()

--- a/UsdConverter/CMakeLists.txt
+++ b/UsdConverter/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2020 Foundry
+# Copyright 2021 Foundry
 #
 # Licensed under the Apache License, Version 2.0 (the "Apache License")
 # with the following modification; you may not use this file except in

--- a/UsdConverter/include/UsdConverter/UsdAttrConverter.h
+++ b/UsdConverter/include/UsdConverter/UsdAttrConverter.h
@@ -1,4 +1,4 @@
-// Copyright 2020 Foundry
+// Copyright 2021 Foundry
 //
 // Licensed under the Apache License, Version 2.0 (the "Apache License")
 // with the following modification; you may not use this file except in

--- a/UsdConverter/include/UsdConverter/UsdAxisScenePlugin.h
+++ b/UsdConverter/include/UsdConverter/UsdAxisScenePlugin.h
@@ -1,4 +1,4 @@
-// Copyright 2020 Foundry
+// Copyright 2021 Foundry
 //
 // Licensed under the Apache License, Version 2.0 (the "Apache License")
 // with the following modification; you may not use this file except in
@@ -21,38 +21,43 @@
 // language governing permissions and limitations under the Apache License.
 
 /*! \file
- \brief Header file for UsdConverter types
+ \brief USD plugin for Axis node
  */
 
-#ifndef USD_TYPES_H
-#define USD_TYPES_H
+#ifndef USDAXISSCENEPLUGIN_H
+#define USDAXISSCENEPLUGIN_H
 
-// Standard includes
-#include <map>
-#include <string>
-#include <vector>
+#include "UsdSceneReader.h"
 
 namespace Foundry
 {
   namespace UsdConverter
   {
-    /*! Holds lists with USD prim data to insert into the scene graph knob
-     *
-     * The scene graph knob displays prim names (e.g. "/world/triangle") and their
-     * corresponding types (e.g. "Mesh"). They are passed using this map with
-     * the required keys "name" and "type", and the map values are string
-     * vectors holding the prim names and their types. Elements with the same index
-     * in each string vector belong together.
-     *
-     * Example: display 2 prims "/world/triangle" (type "Mesh") and "/world/box" (type "Cube"):
-     * {
-     *   "name": ["/world/triangle", "/world/box"],
-     *   "type": ["Mesh",            "Cube"      ],
-     * }
-     */
-    using PrimitiveData = std::map<std::string, std::vector<std::string>>;
+    /// plugin class for the Nuke Axis node
+    class UsdAxisReader : public UsdSceneReaderBase {
+    public:
+      /*! adds usd knobs after the file knobs.
+      * \param cb knob create or store callback.
+      */
+      void knobs(DD::Image::Knob_Callback cb) override;
 
-  }  //namespace UsdConverter
-}  // namespace Foundry
+    protected:
+      /*!
+       * For axis we must have one scene item for every prim
+       * \param filename the path to the usd file.
+       * \return a colection if successful, else returns an empty vector.
+       */
+      DD::Image::SceneItems loadUsdPrims(const char* pFilename) const override;
+
+      /*! check if the primitive is supported by the usd axis plugin
+       * \param prim to check
+       * \return true if the primitive can be loaded into Nuke, false otherwise
+       */
+      bool isPrimSupported(const PXR_NS::UsdPrim& prim) const override;
+
+      virtual void setupSceneGraph() const override;
+    };
+  }
+}
 
 #endif

--- a/UsdConverter/include/UsdConverter/UsdCameraScenePlugin.h
+++ b/UsdConverter/include/UsdConverter/UsdCameraScenePlugin.h
@@ -1,0 +1,97 @@
+// Copyright 2021 Foundry
+//
+// Licensed under the Apache License, Version 2.0 (the "Apache License")
+// with the following modification; you may not use this file except in
+// compliance with the Apache License and the following modification to it:
+// Section 6. Trademarks. is deleted and replaced with:
+//
+// 6. Trademarks. This License does not grant permission to use the trade
+//    names, trademarks, service marks, or product names of the Licensor
+//    and its affiliates, except as required to comply with Section 4(c) of
+//    the License and to reproduce the content of the NOTICE file.
+//
+// You may obtain a copy of the Apache License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the Apache License with the above modification is
+// distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the Apache License for the specific
+// language governing permissions and limitations under the Apache License.
+
+/*! \file
+ \brief USD plugin for Camera node
+ */
+
+#ifndef USDCAMERASCENEPLUGIN_H
+#define USDCAMERASCENEPLUGIN_H
+
+#include "UsdSceneReader.h"
+
+namespace Foundry
+{
+  namespace UsdConverter
+  {
+    /// plugin class for the Nuke Camera node
+    class UsdCameraReader : public UsdSceneReaderBase {
+    public:
+      UsdCameraReader();
+      ~UsdCameraReader() override;
+
+      /*! adds usd knobs after the file knobs.
+      * \param cb knob create or store callback.
+      */
+      void knobs(DD::Image::Knob_Callback cb) override;
+      /// return any usd camera specific knobs
+      std::vector<DD::Image::Knob*> getFileDependentKnobs(DD::Image::SceneReader* reader) override;
+
+    protected:
+      /// set all the camera knobs as animated
+      void setCustomKnobsAsAnimated(const PXR_NS::UsdPrim& prim, const DD::Image::Op& op) const override;
+      /// remove the animation from all the camera knobs
+      void clearCustomAnimation(const PXR_NS::UsdPrim& prim, const DD::Image::Op& op) const override;
+      /*! load the projection and non-animated parameters into the camera knobs
+       * \param prim the camera primitive to load
+       * \param op the camera op to change the knobs on
+       */
+      void setCustomConstantAttributes(const PXR_NS::UsdPrim& prim, DD::Image::Op& op) const override;
+      /*! load all the animated parameters into the camera knobs
+       * \param prim the camera primitive to load
+       * \param op the camera op to change the knobs on
+       * \param time the time to set the values at
+       */
+      void setCustomAnimationAttributes(const PXR_NS::UsdPrim& prim, DD::Image::Op & op, float time) const override;
+      /*! check if the primitive is supported by the usd camera plugin
+       * \param prim to check
+       * \return true if the primitive can be loaded into Nuke, false otherwise
+       */
+      bool isPrimSupported(const PXR_NS::UsdPrim& prim) const override;
+    private:
+      /**
+      * Loads camera's animated attributes from a UsdGeomCamera to a camera operator object
+      * \param const UsdPrim& prim - contains required attributes
+      * \param float time - frame number from which the attributes are loaded
+      * \param Image::Op op - target object
+      */
+      void setCameraAnimationAttribute(const PXR_NS::UsdGeomCamera& camera, float frame, DD::Image::Op & cameraOperator)const;
+      /*! set the camera aperature offset (the window translate)
+       * \param camera the camera to load values from
+       * \param frame frame number to load the values from
+       * \param cameraOperator operator to load the values into
+       */
+      void loadCameraApertureOffset(const PXR_NS::UsdGeomCamera& camera, float frame, DD::Image::Op & cameraOperator) const;
+      /*! set the camera projection attributes, such as whether or not it's orthographic, etc
+       * \param camera the camera to load values from
+       * \param cameraOperator operator to load the values into
+       */
+      void loadCameraProjection(const PXR_NS::UsdGeomCamera& camera, DD::Image::Op & cameraOp) const;
+      /*! set the scale and roll
+       * \param op operator to load the values into
+       */
+      void setConstantCameraAttributes(DD::Image::Op & op) const;
+    };
+  }
+}
+
+#endif

--- a/UsdConverter/include/UsdConverter/UsdCommon.h
+++ b/UsdConverter/include/UsdConverter/UsdCommon.h
@@ -1,4 +1,4 @@
-// Copyright 2020 Foundry
+// Copyright 2021 Foundry
 //
 // Licensed under the Apache License, Version 2.0 (the "Apache License")
 // with the following modification; you may not use this file except in
@@ -20,51 +20,19 @@
 // KIND, either express or implied. See the Apache License for the specific
 // language governing permissions and limitations under the Apache License.
 
-/*! \file
- \brief Implementation file for UsdConverter unit test helpers
- */
+#include <pxr/base/gf/matrix4d.h>
+#include <pxr/base/tf/token.h>
 
-#include "TestFixtures.h"
-
-#include <DDImage/GeoOp.h>
-#include <DDImage/Scene.h>
-
-using namespace DD::Image;
-
-TestGeoOp::TestGeoOp() : GeoOp(nullptr)
+namespace Foundry
 {
-  setupScene();
-}
+  namespace UsdConverter
+  {
+    /*! Apply a rotation to a matrix to convert from the axis direction defined by the token to Nuke's
+     * axis direction (Y up)
+     * \param mat the matrix on which to apply the transoform
+     * \param upAxis token defining the up axis direction we are converting from ("X", "Y" or "Z")
+     */
+    void ApplyUpAxisRotation(PXR_NS::GfMatrix4d& mat, const PXR_NS::TfToken& upAxis);
 
-const char* TestGeoOp::node_help() const
-{
-  return "geo op for testing";
-}
-
-const char* TestGeoOp::Class() const
-{
-  return "TestGeoOp";
-}
-
-GeometryList* TestGeoOp::geometryList()
-{
-  return scene()->object_list();
-}
-
-MemoryAllocator::MemoryAllocator()
-{
-  Allocators::g3DAllocator =
-      Memory::create_allocator<BlockAllocator>("3D System");
-}
-
-MemoryAllocator::~MemoryAllocator()
-{
-  Memory::unregister_allocator(Allocators::g3DAllocator);
-  delete Allocators::g3DAllocator;
-}
-
-std::ostream& DD::Image::operator<<(std::ostream& o, const Vector3& v)
-{
-  o << '{' << v.x << ' ' << v.y << ' ' << v.z << '}';
-  return o;
-}
+  }  // namespace UsdConverter
+}  // namespace Foundry

--- a/UsdConverter/include/UsdConverter/UsdConverterApi.h
+++ b/UsdConverter/include/UsdConverter/UsdConverterApi.h
@@ -1,4 +1,4 @@
-// Copyright 2020 Foundry
+// Copyright 2021 Foundry
 //
 // Licensed under the Apache License, Version 2.0 (the "Apache License")
 // with the following modification; you may not use this file except in

--- a/UsdConverter/include/UsdConverter/UsdGeoConverter.h
+++ b/UsdConverter/include/UsdConverter/UsdGeoConverter.h
@@ -1,4 +1,4 @@
-// Copyright 2020 Foundry
+// Copyright 2021 Foundry
 //
 // Licensed under the Apache License, Version 2.0 (the "Apache License")
 // with the following modification; you may not use this file except in

--- a/UsdConverter/include/UsdConverter/UsdGeoConverter.h
+++ b/UsdConverter/include/UsdConverter/UsdGeoConverter.h
@@ -35,7 +35,6 @@
 #define USD_CONVERTER_H
 
 #include <UsdConverter/UsdConverterApi.h>
-#include <UsdConverter/UsdTypes.h>
 
 // Standard includes
 #include <memory>
@@ -46,6 +45,7 @@
 #include <pxr/base/tf/type.h>
 #include <pxr/pxr.h>
 
+#include <DDImage/SceneItem.h>
 namespace DD
 {
   namespace Image
@@ -103,10 +103,18 @@ namespace Foundry
 
     /*! Get a list of primitive data for all prims in a USD file
      * \param filename  USD file to load
+     * \param types map of primitive type to nuke node to create
      * \return PrimitiveData object containing prim paths and their types
      */
-    FN_USDCONVERTER_API PrimitiveData
-    getPrimitiveData(const std::string& filename);
+    FN_USDCONVERTER_API DD::Image::SceneItems
+    getPrimitiveData(const std::string& filename, const std::unordered_map<std::string, std::string>& types);
+    /*! Get a list of primitive data for all prims in a stage
+     * \param stage USD stage to load
+     * \param types map of primitive type to nuke node to create
+     * \return PrimitiveData object containing prim paths and their types
+     */
+    FN_USDCONVERTER_API DD::Image::SceneItems
+    getPrimitiveData(const PXR_NS::UsdStageRefPtr& stage, const std::unordered_map<std::string, std::string>& types);
 
     // PRIVATE API
     /*! Identify the USD prim type and if supported convert it to Nuke geometry
@@ -117,6 +125,7 @@ namespace Foundry
      */
     int addUsdPrim(DD::Image::GeometryList& out, const PXR_NS::UsdPrim& prim,
                    const PXR_NS::UsdTimeCode time);
+
   }  //namespace UsdConverter
 }  // namespace Foundry
 

--- a/UsdConverter/include/UsdConverter/UsdLightScenePlugin.h
+++ b/UsdConverter/include/UsdConverter/UsdLightScenePlugin.h
@@ -1,0 +1,114 @@
+// Copyright 2021 Foundry
+//
+// Licensed under the Apache License, Version 2.0 (the "Apache License")
+// with the following modification; you may not use this file except in
+// compliance with the Apache License and the following modification to it:
+// Section 6. Trademarks. is deleted and replaced with:
+//
+// 6. Trademarks. This License does not grant permission to use the trade
+//    names, trademarks, service marks, or product names of the Licensor
+//    and its affiliates, except as required to comply with Section 4(c) of
+//    the License and to reproduce the content of the NOTICE file.
+//
+// You may obtain a copy of the Apache License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the Apache License with the above modification is
+// distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the Apache License for the specific
+// language governing permissions and limitations under the Apache License.
+
+/*! \file
+ \brief USD plugin for Light node
+ */
+
+#ifndef USDLIGHTSCENEPLUGIN_H
+#define USDLIGHTSCENEPLUGIN_H
+
+#include "UsdSceneReader.h"
+#include <pxr/usd/usdLux/shapingAPI.h>
+
+namespace Foundry
+{
+  namespace UsdConverter
+  {
+    /// plugin class for the Nuke Light node
+    class UsdLightReader : public UsdSceneReaderBase {
+    public:
+      /*! adds usd knobs after the file knobs.
+      * \param cb knob create or store callback.
+      */
+      void knobs(DD::Image::Knob_Callback cb) override;
+      /// return any usd light specific knobs
+      std::vector<DD::Image::Knob*> getFileDependentKnobs(DD::Image::SceneReader* reader) override;
+
+    protected:
+      void setCustomConstantAttributes(const PXR_NS::UsdPrim& prim, DD::Image::Op& op) const override;
+      /// set all the light knobs as animated
+      void setCustomKnobsAsAnimated(const PXR_NS::UsdPrim& prim, const DD::Image::Op& op) const override;
+      /// remove the animation from all the light knobs
+      void clearCustomAnimation(const PXR_NS::UsdPrim& prim, const DD::Image::Op& op) const override;
+       /*! load all the animated parameters into the light knobs
+        * \param prim the light primitive to load
+        * \param op the light op to change the knobs on
+        * \param time the time to set the values at
+        */
+      void setCustomAnimationAttributes(const PXR_NS::UsdPrim& prim, DD::Image::Op & op, float time) const override;
+      /*! check if the primitive is supported by the usd light plugin
+       * \param prim to check
+       * \return true if the primitive can be loaded into Nuke, false otherwise
+       */
+      bool isPrimSupported(const PXR_NS::UsdPrim& prim) const override;
+      /*!
+       * retrieve a colelction of usd lights. Unsupported light types are disabled.
+       * \param filename the path to the usd file.
+       * \return a collection if usd lights if successful, else returns an empty vector.
+      */
+      DD::Image::SceneItems loadUsdPrims(const char* pFilename) const override;
+    private:
+      /*! load light intensity value from a usd attribute
+      * \param usd attribute containing the intensity value
+      * \param op the light op to change the knobs on
+      * \param time the time to set the values at
+      */
+      bool setIntensity(const PXR_NS::UsdAttribute& attribute, DD::Image::Op & op, float frame) const;
+      /*! load light color from a usd attribute
+      * \param attribute the usd attribute containing the intensity value
+      * \param op the light op to change the knobs on
+      * \param time the time to set the values at
+      */
+      bool setColor(const PXR_NS::UsdAttribute& attribute, DD::Image::Op & op, float frame) const;
+
+      /*! load light cone angle and fall of from a USD light primitive
+      * \param prim the light prim to load
+      * \param op the light op to change the knobs on
+      * \param time the time to set the values at
+      */
+      void setLightCone(const PXR_NS::UsdLuxShapingAPI& prim, DD::Image::Op & op, float time) const;
+
+      /*! check if the primitive has light shape parameters like cone angle and cone softness
+       * \param prim to check
+       * \return true if the primitive is a spot light, false otherwise
+      */
+      bool isSpotLight(const PXR_NS::UsdPrim& prim) const;
+
+      /*! returns a usd light color attribute
+       * The light color attribute name was changed in USD version 21.05 (from 'color' to 'inputs:color').
+       * The function can handle both, the old and the new name, and return a correct light color.
+       * \param source prim
+       */
+      PXR_NS::UsdAttribute GetLightColorAttribute(const PXR_NS::UsdPrim& prim) const;
+
+      /*! returns a usd color intensity attribute
+       * The light intensity attribute name was changed in USD version 21.05 (from 'intensity' to 'inputs:intensity').
+       * The function can handle both, the old and the new name, and return a correct intensity value.
+       * \param source prim
+       */
+      PXR_NS::UsdAttribute GetLightIntensityAttribute(const PXR_NS::UsdPrim& prim) const;
+    };
+  }
+}
+
+#endif

--- a/UsdConverter/include/UsdConverter/UsdSceneGraphPlugin.h
+++ b/UsdConverter/include/UsdConverter/UsdSceneGraphPlugin.h
@@ -1,4 +1,4 @@
-// Copyright 2020 Foundry
+// Copyright 2021 Foundry
 //
 // Licensed under the Apache License, Version 2.0 (the "Apache License")
 // with the following modification; you may not use this file except in
@@ -21,50 +21,32 @@
 // language governing permissions and limitations under the Apache License.
 
 /*! \file
- \brief Implementation file for UsdConverter unit test helpers
+ \brief plugin for querying the USD scene to display in the SceneGraphKnob
  */
 
-#include "TestFixtures.h"
+#ifndef USDSCENEGRAPHPLUGIN_H
+#define USDSCENEGRAPHPLUGIN_H
 
-#include <DDImage/GeoOp.h>
-#include <DDImage/Scene.h>
+#include <DDImage/SceneReaderPlugin.h>
+#include <DDImage/SceneGraphBrowserI.h>
 
-using namespace DD::Image;
-
-TestGeoOp::TestGeoOp() : GeoOp(nullptr)
+namespace Foundry
 {
-  setupScene();
+  namespace UsdConverter
+  {
+    /// plugin class for the Nuke SceneGraph
+    class UsdSceneGraphPlugin : public DD::Image::SceneReaderPlugin {
+    public:
+      UsdSceneGraphPlugin();
+      ~UsdSceneGraphPlugin() override;
+
+      /// check if the file can be used by this plugin
+      bool isValid(const std::string& filename) override;
+      /// return a list of primitives
+      bool query(std::istream& in, std::ostream &out) const override;
+    };
+    DD::Image::SceneReaders::PluginDescription usdSceneGraphPlugin(DD::Image::SceneGraph::kSceneGraphPluginClass, { "usd", "usda", "usdc", "usdz" }, DD::Image::SceneReaders::Constructor<UsdSceneGraphPlugin>);
+  }
 }
 
-const char* TestGeoOp::node_help() const
-{
-  return "geo op for testing";
-}
-
-const char* TestGeoOp::Class() const
-{
-  return "TestGeoOp";
-}
-
-GeometryList* TestGeoOp::geometryList()
-{
-  return scene()->object_list();
-}
-
-MemoryAllocator::MemoryAllocator()
-{
-  Allocators::g3DAllocator =
-      Memory::create_allocator<BlockAllocator>("3D System");
-}
-
-MemoryAllocator::~MemoryAllocator()
-{
-  Memory::unregister_allocator(Allocators::g3DAllocator);
-  delete Allocators::g3DAllocator;
-}
-
-std::ostream& DD::Image::operator<<(std::ostream& o, const Vector3& v)
-{
-  o << '{' << v.x << ' ' << v.y << ' ' << v.z << '}';
-  return o;
-}
+#endif

--- a/UsdConverter/include/UsdConverter/UsdSceneReader.h
+++ b/UsdConverter/include/UsdConverter/UsdSceneReader.h
@@ -1,0 +1,198 @@
+// Copyright 2021 Foundry
+//
+// Licensed under the Apache License, Version 2.0 (the "Apache License")
+// with the following modification; you may not use this file except in
+// compliance with the Apache License and the following modification to it:
+// Section 6. Trademarks. is deleted and replaced with:
+//
+// 6. Trademarks. This License does not grant permission to use the trade
+//    names, trademarks, service marks, or product names of the Licensor
+//    and its affiliates, except as required to comply with Section 4(c) of
+//    the License and to reproduce the content of the NOTICE file.
+//
+// You may obtain a copy of the Apache License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the Apache License with the above modification is
+// distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the Apache License for the specific
+// language governing permissions and limitations under the Apache License.
+
+/*! \file
+ \brief USD plugin for SceneReader (used in some 3D system nodes)
+ */
+
+#ifndef USDSCENEREADER_H
+#define USDSCENEREADER_H
+
+//DDImage includes
+#include <DDImage/SceneReaderPlugin.h>
+#include <DDImage/SceneReader.h>
+#include <DDImage/CameraOp.h>
+#include <DDImage/SceneItem.h>
+
+// Library includes
+#include <pxr/pxr.h>
+#include <pxr/usd/usdGeom/camera.h>
+
+namespace Foundry
+{
+  namespace UsdConverter
+  {
+    /// base class for the USD SceneReaderPlugins
+    class UsdSceneReaderBase : public DD::Image::SceneReaderPlugin {
+    public:
+      UsdSceneReaderBase();
+
+      //Transformation knobs
+      static const std::string kTranslateKnobName;
+      static const std::string kRotateKnobName;
+      static const std::string kScaleKnobName;
+      static const std::string kRotOrderKnobName;
+      static const std::string kTransformOrderKnobName;
+      static const std::string kPivotKnobName;
+      static const std::string kUniformScaleKnobName;
+      static const std::string kSkewKnobName;
+
+      /// check if the file can be used by this plugin
+      bool isValid(const std::string& filename) override;
+
+    protected:
+      void setNodeAttributes(DD::Image::SceneReader& reader, const std::string& filename, const std::string& nodename);
+      /**
+      * Loads transform attributes (transform, rotate, scale ...) from a UsdPrim to an operator object
+      * \param const UsdPrim& prim - contains required attributes
+      * \param float time - frame number from which the attributes are loaded
+      * \param Image::Op op - target object
+      */
+      void setTransformationAttributes(const PXR_NS::UsdPrim& prim, DD::Image::Op & op, float time) const;
+      void setConstantTransformationAttributes(DD::Image::Op & op);
+
+      /// create default usd scene knobs
+      virtual void knobs(DD::Image::Knob_Callback cb) override;
+
+      /**
+      * Update plugin parameters when the file or usd knobs change
+      * \param  reader reader that the plugin should operate on
+      * \param Knob* k the knob that has changed
+      * \return true if the knob has been handled by the callback, false otherwise
+      */
+      bool knob_changed(DD::Image::SceneReader* reader, DD::Image::Knob* k) override;
+
+      /// return default usd scene knobs
+      virtual std::vector<DD::Image::Knob*> getFileDependentKnobs(DD::Image::SceneReader* reader) override;
+
+      /**
+       * initializes the scene graph knob by populating it with usd primitives and selecting a default.
+       * \param items a collection of items.
+       */
+      virtual void setupSceneGraph() const;
+
+      /// function can be implemented to set custom knob as animated
+      virtual void setCustomKnobsAsAnimated(const PXR_NS::UsdPrim& prim, const DD::Image::Op& op) const {}
+
+      /// function can be implemented to set custom knobs as not animated
+      virtual void clearCustomAnimation(const PXR_NS::UsdPrim& prim, const DD::Image::Op& op) const {}
+
+      /**
+      Function can be implemented to initialize custom attributes that don't change during animation
+      * \param prim contains required attributes
+      * \param op target object
+      */
+      virtual void setCustomConstantAttributes(const PXR_NS::UsdPrim& prim, DD::Image::Op& op) const {}
+
+      /**
+      Function can be implemented to load custom attributes for each frame
+      * \param prim contains required attributes
+      * \param op target object
+      * \param time frame number from which the attributes are loaded
+      */
+      virtual void setCustomAnimationAttributes(const PXR_NS::UsdPrim& prim, DD::Image::Op & op, float time) const {}
+
+      /**
+      *Determines if the given prim is supported
+      *\param prim a reference to a usd prim object
+      * return false if SceneReader should ignore the prim
+      */
+      virtual bool isPrimSupported(const PXR_NS::UsdPrim& prim) const =0;
+
+      /**
+      * retrieve a collecion of usd primitives associated with this plugin.
+      * \param filename the path to the usd file.
+      * \return a colection if successful, else returns an empty vector.
+      */
+      virtual DD::Image::SceneItems loadUsdPrims(const char* pFilename) const;
+
+      /// helper function to set the animated state of a knob
+      void setKnobIsAnimated(DD::Image::Knob* pKnob, int numChannels) const;
+
+      /// helper function to set the animated state of an op's knob by name
+      void setKnobIsAnimated(const DD::Image::Op& op, const std::string& knobName, int numChannels) const;
+
+      /// helper function to clear the animated state of an op's knob by name
+      void clearKnobAnimated(const DD::Image::Op& op, const std::string& knobName) const;
+
+      void _validate(DD::Image::SceneReader& reader, bool for_real) override;
+
+      DD::Image::Knob* _sceneGraphKnob;
+    private:
+
+      void setKnobsAsAnimated(const PXR_NS::UsdPrim& prim, DD::Image::Op& op) const;
+      void clearAnimation(const PXR_NS::UsdPrim& prim, DD::Image::Op& op) const;
+
+      /**
+      * Checks whether loaded items are supported by the plugin.
+      * \param reader the op plugin that is doing the reading
+      * \param items list of primitives to check
+      * \return the first enabled item, or the empty SceneItem if there isn't anything enabled
+      */
+      DD::Image::SceneItem validateItems(DD::Image::SceneReader& reader, DD::Image::SceneItems& items);
+      std::string _error{""};
+
+      PXR_NS::TfToken _upAxisDirection;
+    };
+
+    template<class T>
+    bool setKnobValue(DD::Image::Op& op, const std::string& knobName, const T& value, const char* errorMsg=nullptr)
+    {
+      const auto pKnob = op.knob(knobName.c_str());
+      if (!pKnob) {
+        if(errorMsg) {
+          op.error(errorMsg);
+        }
+        return false;
+      }
+      pKnob->set_value(value);
+      return true;
+    }
+
+    template<class T>
+    bool setKnobValueAt(DD::Image::Op& op, const std::string& knobName, const T& value, float time, const char* errorMsg=nullptr)
+    {
+      const auto pKnob = op.knob(knobName.c_str());
+      if (!pKnob) {
+        if(errorMsg) {
+          op.error(errorMsg);
+        }
+        return false;
+      }
+      pKnob->set_value_at(value, time);
+      return true;
+    }
+
+    template<class T>
+    bool getUsdAttrib(T& value, const PXR_NS::UsdAttribute& attribute, double time, DD::Image::Op& op, const char* errorMsg=nullptr)
+    {
+      if(!(attribute.HasValue() && attribute.Get<T>(&value, time))) {
+        if(errorMsg) {
+          op.error(errorMsg);
+        }
+        return false;
+      }
+      return true;
+    }
+  }
+}
+#endif

--- a/UsdConverter/include/UsdConverter/UsdUI.h
+++ b/UsdConverter/include/UsdConverter/UsdUI.h
@@ -1,4 +1,4 @@
-// Copyright 2020 Foundry
+// Copyright 2021 Foundry
 //
 // Licensed under the Apache License, Version 2.0 (the "Apache License")
 // with the following modification; you may not use this file except in

--- a/UsdConverter/include/UsdConverter/UsdUI.h
+++ b/UsdConverter/include/UsdConverter/UsdUI.h
@@ -27,14 +27,18 @@
 #ifndef USD_UI_H
 #define USD_UI_H
 
+#include <string>
+#include <unordered_map>
+
 #include <UsdConverter/UsdConverterApi.h>
-#include <UsdConverter/UsdTypes.h>
 
 namespace DD
 {
   namespace Image
   {
     class SceneGraph_KnobI;
+    class SceneItem;
+    typedef std::vector<SceneItem> SceneItems;
   }
 }  // namespace DD
 
@@ -43,6 +47,25 @@ namespace Foundry
   /// for UI integration with nuke
   namespace UsdConverter
   {
+    /// Maps USD prim types to Nuke nodes that can utilize them
+    static const std::unordered_map<std::string, std::string> supportedPrimTypes {
+      {"Mesh", "ReadGeo2"},
+      {"Cube", "ReadGeo2"},
+      {"PointInstancer", "ReadGeo2"},
+      {"Points", "ReadGeo2"},
+      {"Camera", "Camera3"},
+      {"DistantLight", "Light3"},
+      {"SphereLight", "Light3"}
+    };
+
+    static const std::unordered_map<std::string, std::string> supportedGeoTypes {
+      {"Mesh", "ReadGeo2"},
+      {"Cube", "ReadGeo2"},
+      {"PointInstancer", "ReadGeo2"},
+      {"Points", "ReadGeo2"}
+    };
+
+
     /*! launch a scene view browser with data from the filename
     * \param pSceneGraphKnob the scene view graph knob
     * \param filename the name of the usd file to load
@@ -57,18 +80,21 @@ namespace Foundry
     /*! internal function for filling the scene view knob with data
     * \param pSceneGraphKnob the scene view graph knob
     * \param filename the name of the usd file to load
-    * \param primitives values to insert into the scene graph
-       *   accepted keys:
-       *     "name" - the name of the item in the list
-       *     "type" - the type of the item
+    * \param items collection of scene items to insert into the scene
     * \param showBrowser True if the scene browser is launched as a pop up
     * \param resetSelected True if the contents of the scene browser should be reset to what is in the file
     * \return False if the browser was requested but could not be created
     */
     bool PopulateSceneGraph(DD::Image::SceneGraph_KnobI* pSceneGraphKnob,
                             const char* filename,
-                            const PrimitiveData& primitives, bool showBrowser,
+                            const DD::Image::SceneItems& items, bool showBrowser,
                             bool resetSelected);
+
+    /*! Respond to queries about the USD file
+     * \param in arguments into the function, either SceneGraph::kSceneGraphKnobCommand or SceneGraph::kSceneGraphTypeCommand
+     * \returns true if there were any primitives, false otherwise
+     */
+    FN_USDCONVERTER_API bool QueryPrimitives(std::istream& in, std::ostream &out);
   }  //namespace UsdConverter
 }  // namespace Foundry
 

--- a/UsdConverter/src/UsdAttrConverter.cpp
+++ b/UsdConverter/src/UsdAttrConverter.cpp
@@ -1,4 +1,4 @@
-// Copyright 2020 Foundry
+// Copyright 2021 Foundry
 //
 // Licensed under the Apache License, Version 2.0 (the "Apache License")
 // with the following modification; you may not use this file except in

--- a/UsdConverter/src/UsdAxisScenePlugin.cpp
+++ b/UsdConverter/src/UsdAxisScenePlugin.cpp
@@ -1,0 +1,74 @@
+// Copyright 2021 Foundry
+//
+// Licensed under the Apache License, Version 2.0 (the "Apache License")
+// with the following modification; you may not use this file except in
+// compliance with the Apache License and the following modification to it:
+// Section 6. Trademarks. is deleted and replaced with:
+//
+// 6. Trademarks. This License does not grant permission to use the trade
+//    names, trademarks, service marks, or product names of the Licensor
+//    and its affiliates, except as required to comply with Section 4(c) of
+//    the License and to reproduce the content of the NOTICE file.
+//
+// You may obtain a copy of the Apache License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the Apache License with the above modification is
+// distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the Apache License for the specific
+// language governing permissions and limitations under the Apache License.
+
+/*! \file
+ \brief USD axis plugin for axis node
+ */
+
+#include "UsdConverter/UsdAxisScenePlugin.h"
+
+//DDImage includes
+#include <DDImage/Enumeration_KnobI.h>
+#include <DDImage/SceneGraph_KnobI.h>
+
+// Library includes
+#include <pxr/usd/usd/primRange.h>
+#include <pxr/usd/usdGeom/xformCache.h>
+
+namespace Foundry {
+  namespace UsdConverter {
+    PXR_NAMESPACE_USING_DIRECTIVE
+
+    DD::Image::SceneItems UsdAxisReader::loadUsdPrims(const char* pFilename) const
+    {
+      UsdStageRefPtr stage = UsdStage::Open(pFilename);
+      if (!stage) {
+        return {};
+      }
+
+      DD::Image::SceneItems prims;
+      for(const auto& prim : stage->Traverse()) {
+        prims.emplace_back(prim.GetPath().GetString(),
+                           prim.GetTypeName().GetString(),
+                           isPrimSupported(prim));
+      }
+      return prims;
+    }
+
+    bool UsdAxisReader::isPrimSupported(const UsdPrim& prim) const
+    {
+      return prim.IsValid() && prim.IsA<UsdGeomXformable>();
+    }
+
+    void UsdAxisReader::knobs(DD::Image::Knob_Callback cb)
+    {
+      UsdSceneReaderBase::knobs(cb);
+    }
+
+    void UsdAxisReader::setupSceneGraph() const
+    {
+      _sceneGraphKnob->set_flag(DD::Image::Knob::SINGLE_SELECTION_ONLY);
+    }
+
+    DD::Image::SceneReaders::PluginDescription usdAxisDescription("Axis3", { "usd", "usda", "usdc", "usdz" }, DD::Image::SceneReaders::Constructor<UsdAxisReader>);
+  }
+}

--- a/UsdConverter/src/UsdCameraScenePlugin.cpp
+++ b/UsdConverter/src/UsdCameraScenePlugin.cpp
@@ -1,0 +1,191 @@
+// Copyright 2021 Foundry
+//
+// Licensed under the Apache License, Version 2.0 (the "Apache License")
+// with the following modification; you may not use this file except in
+// compliance with the Apache License and the following modification to it:
+// Section 6. Trademarks. is deleted and replaced with:
+//
+// 6. Trademarks. This License does not grant permission to use the trade
+//    names, trademarks, service marks, or product names of the Licensor
+//    and its affiliates, except as required to comply with Section 4(c) of
+//    the License and to reproduce the content of the NOTICE file.
+//
+// You may obtain a copy of the Apache License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the Apache License with the above modification is
+// distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the Apache License for the specific
+// language governing permissions and limitations under the Apache License.
+
+/*! \file
+ \brief USD Camera plugin for camera node
+ */
+
+#include "UsdConverter/UsdCameraScenePlugin.h"
+
+//DDImage includes
+#include <DDImage/Enumeration_KnobI.h>
+#include <DDImage/SceneGraph_KnobI.h>
+
+// Library includes
+#include <pxr/usd/usd/primRange.h>
+#include <pxr/usd/usdGeom/xformCache.h>
+
+//"Projection" tab knobs
+static const std::string kProjectionKnobName = "projection_mode"; //Camera projection
+static const std::string kFocalLengthKnobName = "focal";          //Focal lenght
+static const std::string kHorizApertureKnobName = "haperture";    //Horizontal aperture
+static const std::string kVertApertureKnobName = "vaperture";     //Vertical aperture
+static const std::string kNearKnobName = "near";                  //Near clipping plane
+static const std::string kFarKnobName = "far";                    //Far clipping plane
+static const std::string kFocalDistanceKnobName = "focal_point";  //Focal distance
+static const std::string kFStopKnobName = "fstop";                //Fstop
+static const std::string kWinTranslateKnobName = "win_translate"; //Camera aperture offset
+static const std::string kWinScaleKnobName = "win_scale";
+static const std::string kWinRollKnobName = "winroll";
+
+const static auto kCameraKnobs = {
+  kFocalLengthKnobName, kHorizApertureKnobName, kVertApertureKnobName, kNearKnobName,
+  kFarKnobName, kFocalDistanceKnobName, kFStopKnobName };
+
+namespace Foundry {
+  namespace UsdConverter {
+    PXR_NAMESPACE_USING_DIRECTIVE
+
+      UsdCameraReader::UsdCameraReader() : UsdSceneReaderBase()
+    {}
+
+    UsdCameraReader::~UsdCameraReader()
+    {
+    }
+
+    std::vector<DD::Image::Knob*> UsdCameraReader::getFileDependentKnobs(DD::Image::SceneReader* reader)
+    {
+      return UsdSceneReaderBase::getFileDependentKnobs(reader);
+    }
+
+    void UsdCameraReader::knobs(DD::Image::Knob_Callback cb)
+    {
+      UsdSceneReaderBase::knobs(cb);
+    }
+
+    void UsdCameraReader::setCustomKnobsAsAnimated(const UsdPrim&, const DD::Image::Op& op) const
+    {
+      for(const auto& knobName : kCameraKnobs) {
+        setKnobIsAnimated(op, knobName, 1);
+      }
+    }
+
+    void UsdCameraReader::clearCustomAnimation(const UsdPrim&, const DD::Image::Op& op) const
+    {
+      for(const auto& knobName : kCameraKnobs) {
+        clearKnobAnimated(op, knobName);
+      }
+      clearKnobAnimated(op, kWinTranslateKnobName);
+    }
+
+    void UsdCameraReader::setCustomConstantAttributes(const UsdPrim& prim, DD::Image::Op& op) const
+    {
+      const UsdGeomCamera camera(prim);
+      loadCameraProjection(camera, op);
+      setConstantCameraAttributes(op);
+    }
+
+    void UsdCameraReader::setCustomAnimationAttributes(const UsdPrim& prim, DD::Image::Op & op, float time) const
+    {
+      const UsdGeomCamera camera(prim);
+      setCameraAnimationAttribute(camera, time, op);
+    }
+
+    bool UsdCameraReader::isPrimSupported(const UsdPrim& prim) const
+    {
+      return prim.IsA<UsdGeomCamera>();
+    }
+
+    void UsdCameraReader::setCameraAnimationAttribute(const UsdGeomCamera& camera, float frame, DD::Image::Op & cameraOperator) const
+    {
+      typedef UsdAttribute(UsdGeomCamera::*GetAttribFunc)() const;
+      const auto loadKnobValue = [&camera, &cameraOperator, &frame](const std::string& knobName, GetAttribFunc pFunc) {
+        float value = 0.0;
+        return getUsdAttrib(value, (camera.*pFunc)(), frame, cameraOperator, ("Could not get attribute for " + knobName).c_str())
+            && setKnobValueAt(cameraOperator, knobName, value, frame, ("Could not set knob " + knobName).c_str());
+      };
+
+      //Focal length
+      loadKnobValue(kFocalLengthKnobName, &UsdGeomCamera::GetFocalLengthAttr);
+
+      //Horizontal Aperture
+      loadKnobValue(kHorizApertureKnobName, &UsdGeomCamera::GetHorizontalApertureAttr);
+
+      //Vertical Aperture
+      loadKnobValue(kVertApertureKnobName, &UsdGeomCamera::GetVerticalApertureAttr);
+
+      //Focal point
+      loadKnobValue(kFocalDistanceKnobName, &UsdGeomCamera::GetFocusDistanceAttr);
+
+      //FStop
+      loadKnobValue(kFStopKnobName, &UsdGeomCamera::GetFStopAttr);
+
+      //Window translate
+      loadCameraApertureOffset(camera, frame, cameraOperator);
+
+      //Clipping range
+      GfVec2f clippingRange;
+      if(getUsdAttrib(clippingRange, camera.GetClippingRangeAttr(), frame, cameraOperator, "no \"clippingRange\" GfVec2fAttr")) {
+        setKnobValueAt(cameraOperator, kNearKnobName, clippingRange[0], frame, ("No " + kNearKnobName + " knob").c_str());
+        setKnobValueAt(cameraOperator, kFarKnobName,  clippingRange[1], frame, ("No " + kFarKnobName + " knob").c_str());
+      }
+    }
+
+    void UsdCameraReader::loadCameraApertureOffset(const UsdGeomCamera& camera, float frame, DD::Image::Op & op)const
+    {
+      float horizontalOffset = 0.0f, verticalOffset = 0.0f, horizontalAperture = 0.0f, verticalAperture = 0.0f;
+      if(   !getUsdAttrib(horizontalOffset,   camera.GetHorizontalApertureOffsetAttr(), frame, op, "no \" HorizontalApertureOffset \" attribute")
+         || !getUsdAttrib(verticalOffset,     camera.GetVerticalApertureOffsetAttr(),   frame, op, "no \" VerticalApertureOffset \" attribute")
+         || !getUsdAttrib(horizontalAperture, camera.GetHorizontalApertureAttr(),       frame, op, "no \" HorizontalAperture \" attribute")
+         || !getUsdAttrib(verticalAperture,   camera.GetVerticalApertureAttr(),         frame, op, "no \" VerticalAperture \" attribute")) {
+        return;
+      }
+
+      if (horizontalAperture > 0.0f)
+        horizontalOffset = horizontalOffset * 2.0f / horizontalAperture;
+
+      if (verticalAperture > 0.0f)
+        verticalOffset = verticalOffset * 2.0f / verticalAperture;
+
+      const auto pKnob = op.knob(kWinTranslateKnobName.c_str());
+      if(pKnob) {
+        pKnob->set_value_at(horizontalOffset, frame, 0);
+        pKnob->set_value_at(verticalOffset, frame, 1);
+      }
+      else {
+        op.error(("no \"" + kWinTranslateKnobName + "\" Knob").c_str());
+      }
+    }
+
+    void UsdCameraReader::loadCameraProjection(const UsdGeomCamera& camera, DD::Image::Op & cameraOp) const
+    {
+      TfToken projectionToken;
+      if(getUsdAttrib(projectionToken, camera.GetProjectionAttr(), UsdTimeCode::Default().GetValue(), cameraOp, "no \"Projection\" attribute")) {
+        const int cameraProjection = (projectionToken == UsdGeomTokens->orthographic) ? DD::Image::CameraOp::LENS_ORTHOGRAPHIC
+                                                                                      : DD::Image::CameraOp::LENS_PERSPECTIVE;
+        setKnobValue(cameraOp, kProjectionKnobName, cameraProjection, ("No " + kProjectionKnobName + " knob").c_str());
+      }
+    }
+
+    void UsdCameraReader::setConstantCameraAttributes(DD::Image::Op & op) const
+    {
+      DD::Image::Knob*pKnob = nullptr;
+      const double win_scale[3] = { 1.0, 1.0 };
+      if((pKnob = op.knob(kWinScaleKnobName.c_str())) != nullptr) {
+        pKnob->set_values(win_scale, 2);
+      }
+      setKnobValue(op, kWinRollKnobName, 0.0f);
+    }
+
+    DD::Image::SceneReaders::PluginDescription usdCameraDescription("Camera3", { "usd", "usda", "usdc", "usdz" }, DD::Image::SceneReaders::Constructor<UsdCameraReader>);
+  }
+}

--- a/UsdConverter/src/UsdCommon.cpp
+++ b/UsdConverter/src/UsdCommon.cpp
@@ -1,4 +1,4 @@
-// Copyright 2020 Foundry
+// Copyright 2021 Foundry
 //
 // Licensed under the Apache License, Version 2.0 (the "Apache License")
 // with the following modification; you may not use this file except in
@@ -21,50 +21,30 @@
 // language governing permissions and limitations under the Apache License.
 
 /*! \file
- \brief Implementation file for UsdConverter unit test helpers
+ \brief Rotation function for camera matrix
  */
 
-#include "TestFixtures.h"
+#include "UsdConverter/UsdCommon.h"
+#include <pxr/usd/usdGeom/tokens.h>
 
-#include <DDImage/GeoOp.h>
-#include <DDImage/Scene.h>
-
-using namespace DD::Image;
-
-TestGeoOp::TestGeoOp() : GeoOp(nullptr)
+namespace Foundry
 {
-  setupScene();
-}
-
-const char* TestGeoOp::node_help() const
-{
-  return "geo op for testing";
-}
-
-const char* TestGeoOp::Class() const
-{
-  return "TestGeoOp";
-}
-
-GeometryList* TestGeoOp::geometryList()
-{
-  return scene()->object_list();
-}
-
-MemoryAllocator::MemoryAllocator()
-{
-  Allocators::g3DAllocator =
-      Memory::create_allocator<BlockAllocator>("3D System");
-}
-
-MemoryAllocator::~MemoryAllocator()
-{
-  Memory::unregister_allocator(Allocators::g3DAllocator);
-  delete Allocators::g3DAllocator;
-}
-
-std::ostream& DD::Image::operator<<(std::ostream& o, const Vector3& v)
-{
-  o << '{' << v.x << ' ' << v.y << ' ' << v.z << '}';
-  return o;
-}
+  namespace UsdConverter
+  {
+    void ApplyUpAxisRotation(PXR_NS::GfMatrix4d& mat, const PXR_NS::TfToken& upAxis)
+    {
+      if(upAxis== PXR_NS::UsdGeomTokens->z) {
+        mat *= PXR_NS::GfMatrix4d( 1, 0, 0, 0,
+                                   0, 0,-1, 0,
+                                   0, 1, 0, 0,
+                                   0, 0, 0, 1); // Rotate in X
+      }
+      else if (upAxis == PXR_NS::UsdGeomTokens->x) {
+        mat *= PXR_NS::GfMatrix4d( 0, 1, 0, 0,
+                                  -1, 0, 0, 0,
+                                   0, 0, 1, 0,
+                                   0, 0, 0, 1); // Rotate in Z
+      }
+    }
+  }  // namespace UsdConverter
+}  // namespace Foundry

--- a/UsdConverter/src/UsdGeoConverter.cpp
+++ b/UsdConverter/src/UsdGeoConverter.cpp
@@ -1,4 +1,4 @@
-// Copyright 2020 Foundry
+// Copyright 2021 Foundry
 //
 // Licensed under the Apache License, Version 2.0 (the "Apache License")
 // with the following modification; you may not use this file except in

--- a/UsdConverter/src/UsdGeoConverter.cpp
+++ b/UsdConverter/src/UsdGeoConverter.cpp
@@ -28,8 +28,11 @@
 #include <DDImage/Particles.h>
 #include <DDImage/PolyMesh.h>
 #include <DDImage/RenderParticles.h>
+#include <DDImage/SceneItem.h>
 #include <UsdConverter/UsdAttrConverter.h>
 #include <UsdConverter/UsdGeoConverter.h>
+#include <UsdConverter/UsdCommon.h>
+#include <UsdConverter/UsdUI.h>
 #include <pxr/usd/usd/primRange.h>
 #include <pxr/usd/usd/relationship.h>
 #include <pxr/usd/usdGeom/cube.h>
@@ -38,6 +41,7 @@
 #include <pxr/usd/usdGeom/points.h>
 #include <pxr/usd/usdGeom/primvarsAPI.h>
 #include <pxr/usd/usdGeom/xformCache.h>
+#include <pxr/usd/usdGeom/metrics.h>
 
 using namespace DD::Image;
 
@@ -154,7 +158,7 @@ namespace Foundry
 
     // Helper for adding point instancer geometry
     int AddInstancedPrim(GeometryList& out, const UsdPrim& instance,
-                         const int proto, std::map<TfToken, int>& protoObjects,
+                         const int proto,
                          const std::vector<UsdAttribute>& primAttributes,
                          const std::vector<UsdAttribute>& constantAttributes,
                          const std::vector<UsdAttribute>& remainingAttributes,
@@ -163,8 +167,6 @@ namespace Foundry
                          const ColorUvData& instancerData,
                          const UsdTimeCode time)
     {
-      auto object_it = protoObjects.find(instance.GetName());
-
       UsdAttributeVector instanceAttributes = instance.GetAttributes();
       const auto hasInstancerAttribute = [&](const auto& attribute) {
         return std::any_of(
@@ -182,55 +184,21 @@ namespace Foundry
       instanceAttributes.insert(instanceAttributes.begin(),
                                 constantAttributes.begin(),
                                 constantAttributes.end());
-      int instanceObj = -1;
-      // Convert the primitive once, and then make the other primitives reference its data
-      if(object_it == protoObjects.end()) {
-        instanceObj = addUsdPrim(out, instance, time);
-        ConvertUsdAttributes(out, instanceObj, instanceAttributes, time);
-      }
-      else {
-        instanceObj = out.size();
-        out.add_object(instanceObj);
-        GeoInfo& instanceGeo = out[instanceObj];
-        GeoInfo& protoGeo = out[object_it->second];
-        const GeoInfo::Cache* instanceCache = instanceGeo.get_cache_pointer();
-        const GeoInfo::Cache* protoCache = protoGeo.get_cache_pointer();
-
-        PrimitiveListPtr instancePrimitives = instanceCache->primitives;
-        instancePrimitives = protoCache->primitives;
-
-        PointListPtr instancePoints = instanceCache->points;
-        instancePoints = protoCache->points;
-
-        for(const auto& fromAttr : instanceAttributes) {
-          Attribute* toAttr = ConstructAttribute(out, instanceObj, fromAttr);
-          Attribute* protoAttr = out.writable_attribute(
-              object_it->second, ConvertGroupType(fromAttr), toAttr->name(),
-              toAttr->type());
-          toAttr->float_list = protoAttr->float_list;
-          toAttr->vector2_list = protoAttr->vector2_list;
-          toAttr->vector3_list = protoAttr->vector3_list;
-          toAttr->vector4_list = protoAttr->vector4_list;
-          toAttr->matrix3_list = protoAttr->matrix3_list;
-          toAttr->matrix4_list = protoAttr->matrix4_list;
-          toAttr->string_list = protoAttr->string_list;
-          toAttr->std_string_list = protoAttr->std_string_list;
-          toAttr->pointer_list = protoAttr->pointer_list;
-          toAttr->data = protoAttr->data;
-        }
-      }
-
+      const auto instanceObj = addUsdPrim(out, instance, time);
       if(instanceObj == -1) {
         return instanceObj;
       }
+      ConvertUsdAttributes(out, instanceObj, instanceAttributes, time);
 
       ColorUvData instanceData(instancerData, proto);
       // Apply the attributes that the instancer overrides
       ConvertColorUvs(out, instanceObj, instanceData);
       for(const auto& attribute : remainingAttributes) {
         Attribute* toAttr = ConstructAttribute(out, instanceObj, attribute);
-        ConvertValues(toAttr, attribute, time, proto,
-                      UsdGeomPrimvar(attribute).GetElementSize());
+        if(toAttr) {
+          ConvertValues(toAttr, attribute, time, proto,
+                        UsdGeomPrimvar(attribute).GetElementSize());
+        }
       }
       if(pointInstancerTransforms) {
         ConvertObjectTransform(out, instanceObj, xforms[proto]);
@@ -251,9 +219,6 @@ namespace Foundry
         GeometryList& out, const UsdGeomPointInstancer& fromPrim,
         const UsdTimeCode time)
     {
-      const int obj = out.size();
-      out.add_object(obj);
-
       UsdStageWeakPtr stage = fromPrim.GetPrim().GetStage();
 
       UsdAttribute a_protoIndicies = fromPrim.GetProtoIndicesAttr();
@@ -268,8 +233,14 @@ namespace Foundry
           fromPrim.GetPrim().GetAuthoredAttributes();
 
       VtArray<GfMatrix4d> xforms;
-      bool pointInstancerTransforms =
+      const bool pointInstancerTransforms =
           fromPrim.ComputeInstanceTransformsAtTime(&xforms, time, time);
+
+      UsdGeomXformCache cache(time);
+      const GfMatrix4d worldMatrix = cache.GetLocalToWorldTransform(fromPrim.GetPrim());
+      //Move xforms from local coordinates to world coordinates
+      for (size_t i = 0; i<xforms.size(); ++i)
+        xforms[i] *= worldMatrix;
 
       // Split the attributes into those that need to be applied for all instances, and those that elementSize offsets
       std::vector<UsdAttribute> constantAttributes;
@@ -296,19 +267,34 @@ namespace Foundry
           continue;
         }
         UsdPrim root = stage->GetPrimAtPath(paths[protoIndices[proto]]);
-        std::map<TfToken, int> protoObjects;
-        AddInstancedPrim(out, root, proto, protoObjects, primAttributes,
-                         constantAttributes, remainingAttributes,
-                         pointInstancerTransforms, xforms, instancerData, time);
-        for(const auto& instance : root.GetAllDescendants()) {
-          AddInstancedPrim(out, instance, proto, protoObjects, primAttributes,
-                           constantAttributes, remainingAttributes,
-                           pointInstancerTransforms, xforms, instancerData,
+        if(!root) {
+          continue;
+        }
+
+        const auto addInstance = [&out, &proto,
+                                  &primAttributes, &constantAttributes, &remainingAttributes,
+                                  &pointInstancerTransforms, &xforms,
+                                  &instancerData,
+                                  &time](auto& instance) {
+          AddInstancedPrim(out, instance, proto,
+                           primAttributes, constantAttributes, remainingAttributes,
+                           pointInstancerTransforms,  xforms,
+                           instancerData,
                            time);
+        };
+
+        const auto allDescs = root.GetAllDescendants();
+        if(allDescs.empty()) {
+          addInstance(root);
+        }
+        else {
+          for(const auto& instance : allDescs) {
+            addInstance(instance);
+          }
         }
       }
 
-      return obj;
+      return -1;
     }
 
     // Helpers for UsdGeomCube conversion
@@ -396,27 +382,29 @@ namespace Foundry
       return -1;
     }
 
-    FN_USDCONVERTER_API PrimitiveData
-    getPrimitiveData(const std::string& filename)
+
+    FN_USDCONVERTER_API DD::Image::SceneItems
+    getPrimitiveData(const UsdStageRefPtr& stage, const std::unordered_map<std::string, std::string>& types)
     {
-      PrimitiveData items;
+      DD::Image::SceneItems items;
+      for(const auto& prim : stage->Traverse()) {
+        const auto& primPath = prim.GetPath().GetString();
+        const auto& typeName = prim.GetTypeName();
+        const auto enabled = (types.find(typeName) != types.end());
+        items.emplace_back(primPath, typeName, enabled);
+      }
+      return items;
+    }
+
+    FN_USDCONVERTER_API DD::Image::SceneItems
+    getPrimitiveData(const std::string& filename, const std::unordered_map<std::string, std::string>& types)
+    {
       // Open the stage from file
       UsdStageRefPtr stage = UsdStage::Open(filename);
       if(!stage) {
-        return items;
+        return DD::Image::SceneItems();
       }
-      // Traverse the stage and add all prims and their type to items
-      auto range = UsdPrimRange::PreAndPostVisit(stage->GetPseudoRoot());
-      bool isRecursing = false;
-      for(auto it = range.cbegin(); it != range.cend(); ++it) {
-        if(!isRecursing && it.IsPostVisit()) {
-          const TfToken& type = it->GetTypeName();
-          items["name"].push_back(it->GetPath().GetString());
-          items["type"].push_back(type.GetString());
-        }
-        isRecursing = it.IsPostVisit();
-      }
-      return items;
+      return getPrimitiveData(stage, types);
     }
 
     FN_USDCONVERTER_API void convertUsdGeometry(GeometryList& out,
@@ -426,6 +414,9 @@ namespace Foundry
       // Traverse the stage at the required timecode and convert all loaded USD prims to Nuke geometry
       UsdGeomXformCache cache;
       cache.SetTime(time);
+
+      const TfToken upAxis = UsdGeomGetStageUpAxis(stage);
+
       for(const auto& prim : stage->Traverse()) {
         const int obj = addUsdPrim(out, prim, time);
         if(obj == -1) {
@@ -435,6 +426,7 @@ namespace Foundry
         ConvertUsdAttributes(out, obj, prim.GetAttributes(), time);
         ConvertPrimPath(out, obj, prim);
         GfMatrix4d world = cache.GetLocalToWorldTransform(prim);
+        ApplyUpAxisRotation(world, upAxis);
         ConvertObjectTransform(out, obj, world);
       }
     }

--- a/UsdConverter/src/UsdLightScenePlugin.cpp
+++ b/UsdConverter/src/UsdLightScenePlugin.cpp
@@ -1,0 +1,230 @@
+// Copyright 2021 Foundry
+//
+// Licensed under the Apache License, Version 2.0 (the "Apache License")
+// with the following modification; you may not use this file except in
+// compliance with the Apache License and the following modification to it:
+// Section 6. Trademarks. is deleted and replaced with:
+//
+// 6. Trademarks. This License does not grant permission to use the trade
+//    names, trademarks, service marks, or product names of the Licensor
+//    and its affiliates, except as required to comply with Section 4(c) of
+//    the License and to reproduce the content of the NOTICE file.
+//
+// You may obtain a copy of the Apache License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the Apache License with the above modification is
+// distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the Apache License for the specific
+// language governing permissions and limitations under the Apache License.
+
+/*! \file
+ \brief USD Light plugin for light node
+ */
+
+#include "UsdConverter/UsdLightScenePlugin.h"
+
+//DDImage includes
+#include <DDImage/Enumeration_KnobI.h>
+#include <DDImage/SceneGraph_KnobI.h>
+
+// Library includes
+#include <pxr/usd/usd/primRange.h>
+#include <pxr/usd/usdGeom/xformCache.h>
+#include <pxr/usd/usdLux/distantLight.h>
+#include <pxr/usd/usdLux/sphereLight.h>
+
+//"Light" tab knobs
+static const std::string kLightTypeKnobName = "light_type";
+static const std::string kColorKnobName = "color";
+static const std::string kIntensityKnobName = "intensity";
+static const std::string kFalloffTypeKnobName = "falloff_type";
+static const std::string kConeAngle = "cone_angle";
+static const std::string kConeFalloff = "cone_falloff";
+static const std::string kConePenumbraAngle = "cone_penumbra_angle";
+
+static constexpr int kPointLightType = 0;
+static constexpr int kDirectionalLightType = 1;
+static constexpr int kSpotLightType = 2;
+
+namespace Foundry {
+  namespace UsdConverter {
+    PXR_NAMESPACE_USING_DIRECTIVE
+
+    void UsdLightReader::knobs(DD::Image::Knob_Callback cb)
+    {
+      UsdSceneReaderBase::knobs(cb);
+    }
+
+    std::vector<DD::Image::Knob*> UsdLightReader::getFileDependentKnobs(DD::Image::SceneReader* reader)
+    {
+      auto knobs = UsdSceneReaderBase::getFileDependentKnobs(reader);
+      const auto op = dynamic_cast<DD::Image::Op*>(reader);
+      const auto lightType = static_cast<int>(op->knob(kLightTypeKnobName.c_str())->get_value());
+      switch(lightType) {
+      case kSpotLightType:
+        knobs.emplace_back(op->knob(kConePenumbraAngle.c_str()));
+      case kPointLightType:
+        knobs.emplace_back(op->knob(kFalloffTypeKnobName.c_str()));
+      default:
+        break;
+      }
+      return knobs;
+    }
+
+    void UsdLightReader::setCustomConstantAttributes(const UsdPrim& prim, DD::Image::Op& op) const
+    {
+      if(isSpotLight(prim)) {
+        setKnobValue(op, kLightTypeKnobName, kSpotLightType, "Can not initialize light node");
+      }
+      else if(prim.IsA<UsdLuxSphereLight>()) {
+        setKnobValue(op, kLightTypeKnobName, kPointLightType, "Can not initialize light node");
+      }
+      else {
+        setKnobValue(op, kLightTypeKnobName, kDirectionalLightType, "Can not initialize light node");
+      }
+      if(DD::Image::Knob* knob = op.knob(kLightTypeKnobName.c_str())) {
+        knob->changed();
+      }
+    }
+
+    void UsdLightReader::setCustomKnobsAsAnimated(const UsdPrim& prim, const DD::Image::Op& op) const
+    {
+      setKnobIsAnimated(op, kIntensityKnobName, 1);
+      setKnobIsAnimated(op, kColorKnobName, 3);
+
+      if (isSpotLight(prim)) {
+        setKnobIsAnimated(op, kConeAngle, 1);
+        setKnobIsAnimated(op, kConeFalloff, 1);
+      }
+    }
+
+    void UsdLightReader::clearCustomAnimation(const UsdPrim& /* prim */, const DD::Image::Op& op) const
+    {
+      for(const auto& knobName : { kColorKnobName, kIntensityKnobName, kConeAngle, kConeFalloff }) {
+        clearKnobAnimated(op, knobName);
+      }
+    }
+
+    void UsdLightReader::setCustomAnimationAttributes(const UsdPrim& prim, DD::Image::Op & op, float time) const
+    {
+      const UsdAttribute intensity = GetLightIntensityAttribute(prim);
+      if (!setIntensity(intensity, op, time)) {
+        op.error("Can not initialize intensity_scaled knob");
+        return;
+      }
+
+      const UsdAttribute color = GetLightColorAttribute(prim);
+      if (!setColor(color, op, time)) {
+        op.error("Can not initialize color knob");
+        return;
+      }
+
+      if (isSpotLight(prim)) {
+        UsdLuxShapingAPI lightConeData(prim);
+        setLightCone(lightConeData, op, time);
+      }
+    }
+
+    bool UsdLightReader::isPrimSupported(const UsdPrim& prim) const
+    {
+      return prim.IsValid() && prim.IsA<UsdLuxLight>();
+    }
+
+    DD::Image::SceneItems UsdLightReader::loadUsdPrims(const char* pFilename) const
+    {
+      using namespace std;
+      UsdStageRefPtr stage = UsdStage::Open(pFilename);
+      if (!stage) {
+        return {};
+      }
+
+      DD::Image::SceneItems prims;
+      const auto range = UsdPrimRange(stage->GetPseudoRoot());
+      for (const auto& prim : range) {
+        if (isPrimSupported(prim)) {
+          const bool enabled = prim.IsA< UsdLuxDistantLight>() || prim.IsA< UsdLuxSphereLight>();
+          prims.emplace_back(prim.GetPath().GetString(), prim.GetTypeName().GetString(), enabled);
+        }
+      }
+      return prims;
+    }
+
+    bool UsdLightReader::setIntensity(const PXR_NS::UsdAttribute& attribute, DD::Image::Op & op, float time) const
+    {
+      float intensityValue;
+      return (getUsdAttrib(intensityValue, attribute, time, op)
+              && setKnobValueAt(op, kIntensityKnobName, intensityValue, time));
+    }
+
+    bool UsdLightReader::setColor(const PXR_NS::UsdAttribute& attribute, DD::Image::Op & op, float time) const
+    {
+      GfVec3f colorValue;
+      if(!getUsdAttrib(colorValue, attribute, time, op)) {
+        return false;
+      }
+
+      DD::Image::Knob* pKnob = op.knob(kColorKnobName.c_str());
+      if (!pKnob) {
+        return false;
+      }
+
+      for(int i = 0; i < 3; i++) {
+        pKnob->set_value_at(colorValue[i], time, i);
+      }
+
+      return true;
+    }
+
+    void UsdLightReader::setLightCone(const PXR_NS::UsdLuxShapingAPI& prim, DD::Image::Op & op, float time) const
+    {
+      float coneAngle;
+      float coneSoftness;
+      if(   !getUsdAttrib(coneAngle,    prim.GetShapingConeAngleAttr(),    time, op, "Can not initialize cone angle")
+         || !getUsdAttrib(coneSoftness, prim.GetShapingConeSoftnessAttr(), time, op, "Can not initialize cone falloff")) {
+        return;
+      }
+      setKnobValueAt(op, kConeAngle,   coneAngle,    time, "Can not initialize cone angle");
+      setKnobValueAt(op, kConeFalloff, coneSoftness, time, "Can not initialize cone falloff");
+    }
+
+    bool UsdLightReader::isSpotLight(const PXR_NS::UsdPrim& prim) const
+    {
+      return prim.HasAPI<UsdLuxShapingAPI>() && prim.IsA<UsdLuxSphereLight>();
+    }
+
+    UsdAttribute UsdLightReader::GetLightColorAttribute(const UsdPrim& prim) const
+    {
+      static const TfToken oldAttributeName("color");
+
+      const UsdLuxLight light(prim);
+      UsdAttribute colorAttribute = light.GetColorAttr();
+      const UsdResolveInfoSource source = colorAttribute.GetResolveInfo().GetSource();
+      const bool isDefaultValue = source == UsdResolveInfoSourceFallback;
+
+      if (isDefaultValue && prim.HasAttribute(oldAttributeName)) {
+        colorAttribute = prim.GetAttribute(oldAttributeName);
+      }
+      return colorAttribute;
+    }
+
+    UsdAttribute UsdLightReader::GetLightIntensityAttribute(const UsdPrim& prim) const
+    {
+      static const TfToken oldAttributeName("intensity");
+
+      const UsdLuxLight light(prim);
+      UsdAttribute intensityAttribute = light.GetIntensityAttr();
+      const UsdResolveInfoSource source = intensityAttribute.GetResolveInfo().GetSource();
+      const bool isDefaultValue = source == UsdResolveInfoSourceFallback;
+
+      if (isDefaultValue && prim.HasAttribute(oldAttributeName)) {
+        intensityAttribute = prim.GetAttribute(oldAttributeName);
+      }
+      return intensityAttribute;
+    }
+
+    DD::Image::SceneReaders::PluginDescription usdLightDescription("Light3", { "usd", "usda", "usdc", "usdz" }, DD::Image::SceneReaders::Constructor<UsdLightReader>);
+  }
+}

--- a/UsdConverter/src/UsdSceneGraphPlugin.cpp
+++ b/UsdConverter/src/UsdSceneGraphPlugin.cpp
@@ -1,0 +1,63 @@
+// Copyright 2021 Foundry
+//
+// Licensed under the Apache License, Version 2.0 (the "Apache License")
+// with the following modification; you may not use this file except in
+// compliance with the Apache License and the following modification to it:
+// Section 6. Trademarks. is deleted and replaced with:
+//
+// 6. Trademarks. This License does not grant permission to use the trade
+//    names, trademarks, service marks, or product names of the Licensor
+//    and its affiliates, except as required to comply with Section 4(c) of
+//    the License and to reproduce the content of the NOTICE file.
+//
+// You may obtain a copy of the Apache License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the Apache License with the above modification is
+// distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the Apache License for the specific
+// language governing permissions and limitations under the Apache License.
+
+/*! \file
+ \brief plugin for querying the USD scene to display in the SceneGraphKnob
+ */
+
+#include <iomanip>
+
+#include <DDImage/SceneGraphBrowserI.h>
+
+#include "UsdConverter/UsdSceneGraphPlugin.h"
+#include "UsdConverter/UsdUI.h"
+
+namespace Foundry
+{
+  namespace UsdConverter
+  {
+    UsdSceneGraphPlugin::UsdSceneGraphPlugin() : DD::Image::SceneReaderPlugin() {};
+    UsdSceneGraphPlugin::~UsdSceneGraphPlugin() {}
+
+    /// check if the file can be used by this plugin
+    bool UsdSceneGraphPlugin::isValid(const std::string& filename) { return true; }
+
+    bool UsdSceneGraphPlugin::query(std::istream& in, std::ostream &out) const {
+      std::string command;
+      in >> std::quoted(command);
+      if(command == DD::Image::SceneGraph::kSceneGraphKnobCommand) {
+        return Foundry::UsdConverter::QueryPrimitives(in, out);
+      }
+      else if(command == DD::Image::SceneGraph::kSceneGraphTypeCommand) {
+        std::string opType;
+        in >> std::quoted(opType);
+        const auto& it = supportedPrimTypes.find(opType);
+        if(it == supportedPrimTypes.end()) {
+          return false;
+        }
+        out << std::quoted(it->second);
+        return true;
+      }
+      return false;
+    }
+  }
+}

--- a/UsdConverter/src/UsdSceneReader.cpp
+++ b/UsdConverter/src/UsdSceneReader.cpp
@@ -1,0 +1,368 @@
+// Copyright 2021 Foundry
+//
+// Licensed under the Apache License, Version 2.0 (the "Apache License")
+// with the following modification; you may not use this file except in
+// compliance with the Apache License and the following modification to it:
+// Section 6. Trademarks. is deleted and replaced with:
+//
+// 6. Trademarks. This License does not grant permission to use the trade
+//    names, trademarks, service marks, or product names of the Licensor
+//    and its affiliates, except as required to comply with Section 4(c) of
+//    the License and to reproduce the content of the NOTICE file.
+//
+// You may obtain a copy of the Apache License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the Apache License with the above modification is
+// distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the Apache License for the specific
+// language governing permissions and limitations under the Apache License.
+
+/*! \file
+ \brief USD implementation for SceneReader nodes
+ */
+
+#include "UsdConverter/UsdSceneReader.h"
+#include "UsdConverter/UsdCommon.h"
+
+//DDImage includes
+#include <DDImage/Enumeration_KnobI.h>
+#include <DDImage/SceneGraph_KnobI.h>
+
+// Library includes
+#include <pxr/usd/usd/primRange.h>
+#include <pxr/usd/usdGeom/xformCache.h>
+#include <pxr/usd/usdGeom/metrics.h>
+#include <pxr/usd/usdGeom/tokens.h>
+
+namespace Foundry {
+  namespace UsdConverter {
+    PXR_NAMESPACE_USING_DIRECTIVE
+
+    namespace { //Helper functions
+      DD::Image::Matrix4 getMatrix4(const GfMatrix4d& from)
+      {
+        return DD::Image::Matrix4(
+          (float)from[0][0], (float)from[1][0], (float)from[2][0], (float)from[3][0],
+          (float)from[0][1], (float)from[1][1], (float)from[2][1], (float)from[3][1],
+          (float)from[0][2], (float)from[1][2], (float)from[2][2], (float)from[3][2],
+          (float)from[0][3], (float)from[1][3], (float)from[2][3], (float)from[3][3]);
+      }
+
+      float toDegrees(float radians) {
+        return radians * 180.0f / M_PI_F;
+      }
+
+      float calculateSkew(float shear) {
+        if (shear == 0.0f)
+          return shear;
+        return fmodf(90.0f - (180.0f / M_PI_F)*atanf(1.0f / shear), 180.0f);
+      }
+    }
+
+    //Transformation knobs
+    const std::string UsdSceneReaderBase::kTranslateKnobName = "translate";
+    const std::string UsdSceneReaderBase::kRotateKnobName = "rotate";
+    const std::string UsdSceneReaderBase::kScaleKnobName = "scaling";
+    const std::string UsdSceneReaderBase::kRotOrderKnobName = "rot_order";
+    const std::string UsdSceneReaderBase::kTransformOrderKnobName = "xform_order";
+    const std::string UsdSceneReaderBase::kPivotKnobName = "pivot";
+    const std::string UsdSceneReaderBase::kUniformScaleKnobName = "uniform_scale";
+    const std::string UsdSceneReaderBase::kSkewKnobName = "skew";
+
+    const static auto translationKnobs = { UsdSceneReaderBase::kTranslateKnobName,
+                                           UsdSceneReaderBase::kRotateKnobName,
+                                           UsdSceneReaderBase::kScaleKnobName,
+                                           UsdSceneReaderBase::kSkewKnobName };
+
+    UsdSceneReaderBase::UsdSceneReaderBase() :
+        _sceneGraphKnob(nullptr),
+        _upAxisDirection(UsdGeomTokens->y)
+    {}
+
+    DD::Image::SceneItems UsdSceneReaderBase::loadUsdPrims(const char* pFilename) const
+    {
+      using namespace std;
+      UsdStageRefPtr stage = UsdStage::Open(pFilename);
+      if (!stage) {
+        return {};
+      }
+
+      DD::Image::SceneItems prims;
+      const auto range = UsdPrimRange(stage->GetPseudoRoot());
+      for (const auto& prim : range) {
+        if (isPrimSupported(prim)) {
+          prims.emplace_back(prim.GetPath().GetString(), prim.GetTypeName().GetString());
+        }
+      }
+      return prims;
+    }
+
+    bool UsdSceneReaderBase::knob_changed(DD::Image::SceneReader* reader, DD::Image::Knob* k)
+    {
+      if (!reader->getReadFromFile() || !k) {
+        return false;
+      }
+
+      const bool fileChanged = k->is(DD::Image::kFileKnobName.c_str());
+      const bool fileReloaded = k->is(DD::Image::kReloadKnobName.c_str()) || (k->is(DD::Image::kReadFromFileKnobName.c_str()) && k->get_value());
+      const auto filename = reader->getFilename();
+
+      if (filename.empty()) {
+        return false;
+      }
+      bool result = false;
+      if (fileChanged || fileReloaded) {
+
+        setupSceneGraph();
+        if(reader->getLoadHint()) {
+          DD::Image::SceneItems items = loadUsdPrims(filename.c_str());
+          _sceneGraphKnob->sceneGraphKnob()->setItems(items, false);
+
+          DD::Image::SceneItem item = validateItems(*reader, items);
+          if(!_sceneGraphKnob->sceneGraphKnob()->hasSelection()) {
+            _sceneGraphKnob->sceneGraphKnob()->setSelectedItems({item.name});
+          }
+          result = true;
+        }
+
+        if (fileChanged) {
+          _sceneGraphKnob->sceneGraphKnob()->setFocus();
+        }
+      }
+      else if (k == &DD::Image::Knob::showPanel || k->is(DD::Image::kSceneGraphKnobName)) {
+        auto* sceneGraphKnobI = _sceneGraphKnob->sceneGraphKnob();
+        auto selected_items = sceneGraphKnobI->getSelectedItems(DD::Image::SceneGraph::kNameField);
+        if (!selected_items.empty()) {
+          setNodeAttributes(*reader, filename.c_str(), selected_items.back());
+        }
+        result = true;
+      }
+      return result;
+    }
+
+    void UsdSceneReaderBase::setKnobIsAnimated(DD::Image::Knob* pKnob, int numChannels) const
+    {
+      pKnob->clear_animated(-1);
+      for (int i = 0; i < numChannels; i++)
+        pKnob->set_animated(i);
+    }
+
+    void UsdSceneReaderBase::setKnobIsAnimated(const DD::Image::Op& op, const std::string& knobName, int numChannels) const
+    {
+      const auto pKnob = op.knob(knobName.c_str());
+      if(pKnob) {
+        setKnobIsAnimated(pKnob, numChannels);
+      }
+    }
+
+    void UsdSceneReaderBase::clearKnobAnimated(const DD::Image::Op& op, const std::string& knobName) const
+    {
+      const auto pKnob = op.knob(knobName.c_str());
+      if(pKnob) {
+        pKnob->clear_animated(-1);
+      }
+    }
+
+    void UsdSceneReaderBase::_validate(DD::Image::SceneReader& reader, bool for_real)
+    {
+      if(!_error.empty()) {
+        reader.error(_error.c_str());
+      }
+    }
+
+    bool UsdSceneReaderBase::isValid(const std::string& filename)
+    {
+      return true;
+    }
+
+    void UsdSceneReaderBase::setConstantTransformationAttributes(DD::Image::Op & op) {
+      DD::Image::Knob* pKnob = op.knob(kRotOrderKnobName.c_str());
+      if (pKnob)
+        pKnob->set_value(DD::Image::Matrix4::eXYZ);
+      else
+        throw std::runtime_error("no \""+ kRotOrderKnobName +"\" knob");
+
+      pKnob = op.knob(kTransformOrderKnobName.c_str());
+      if (pKnob)
+        pKnob->set_value(DD::Image::Matrix4::eSRT);
+      else
+        throw std::runtime_error("no \""+ kTransformOrderKnobName +"\" knob");
+
+      pKnob = op.knob(kPivotKnobName.c_str());
+      const double pivot[3] = { 0.0, 0.0, 0.0 };
+      if (pKnob)
+        pKnob->set_values(pivot, 3);
+      else
+        throw std::runtime_error("no \""+ kPivotKnobName +"\" knob");
+
+      pKnob = op.knob(kUniformScaleKnobName.c_str());
+      if (pKnob)
+        pKnob->set_value(1.0f);
+      else
+        throw std::runtime_error("no \"" + kUniformScaleKnobName + "\" knob");
+    }
+
+    void UsdSceneReaderBase::setTransformationAttributes(const UsdPrim& prim, DD::Image::Op & op, float time) const
+    {
+      DD::Image::Knob* pTranslateKnob = op.knob(kTranslateKnobName.c_str());
+      if (!pTranslateKnob)
+        throw std::runtime_error("no \""+ kTranslateKnobName +"\" knob");
+
+      DD::Image::Knob* pRotationKnob = op.knob(kRotateKnobName.c_str());
+      if(!pRotationKnob)
+        throw std::runtime_error("no \""+ kRotateKnobName +"\" knob");
+
+      DD::Image::Knob* pScalingKnob = op.knob(kScaleKnobName.c_str());
+      if(!pScalingKnob)
+        throw std::runtime_error("no \""+ kScaleKnobName +"\" knob");
+
+      DD::Image::Knob* pSkewKnob = op.knob(kSkewKnobName.c_str());
+      if (!pSkewKnob)
+        throw std::runtime_error("no \"" + kSkewKnobName + "\" knob");
+
+      UsdGeomXformCache cache(time);
+      GfMatrix4d world = cache.GetLocalToWorldTransform(prim);
+
+      // Apply axis transform
+      ApplyUpAxisRotation(world, _upAxisDirection);
+
+      //Translation
+      const GfVec3d translation = world.ExtractTranslation();
+      pTranslateKnob->set_values_at(translation.data(), 3, time);
+
+      //Rotation
+      DD::Image::Matrix4 matrix4 = getMatrix4(world);
+
+      const DD::Image::Matrix4::RotationOrder order = DD::Image::Matrix4::eXYZ;
+      float x_rotation, y_rotation, z_rotation;
+      matrix4.getRotations(order, x_rotation, y_rotation, z_rotation);
+      const double euler_angles[3] = { toDegrees(x_rotation), toDegrees(y_rotation), toDegrees(z_rotation) };
+      pRotationKnob->set_values_at(euler_angles, 3, time);
+
+      //Scaling and sheer
+      DD::Image::Vector3 scale;
+      DD::Image::Vector3 shear;
+      matrix4.extractAndRemoveScalingAndShear(scale, shear);
+      pScalingKnob->set_values_at(scale.array(), 3, time);
+
+      for (int i = 0; i < 3; i++) {
+        float skew = calculateSkew(shear[i]);
+        pSkewKnob->set_value_at(skew, time, i);
+      }
+    }
+
+    void UsdSceneReaderBase::setNodeAttributes(DD::Image::SceneReader& reader, const std::string& filename, const std::string& nodename)
+    {
+      DD::Image::Op * op = dynamic_cast<DD::Image::Op*>(&reader);
+      if (!op)
+        return;
+
+      UsdStageRefPtr stage = UsdStage::Open(filename);
+      if (!stage)
+        return;
+
+      _upAxisDirection = UsdGeomGetStageUpAxis(stage);
+
+      const float start = (float)stage->GetStartTimeCode();
+      const float end = (float)stage->GetEndTimeCode();
+
+      const UsdPrim usdPrim = stage->GetPrimAtPath(SdfPath(nodename));
+
+      // the prim doesn't exist at the path
+      if(!usdPrim) {
+        op->error("Primitive doesn't exist: %s", nodename.c_str());
+        return;
+      }
+
+      if (!isPrimSupported(usdPrim))
+        return;
+
+      reader.setStartFrame((float)stage->GetStartTimeCode());
+      reader.setEndFrame((float)stage->GetEndTimeCode());
+
+      DD::Image::Knob * pUserFrameRateKnob = op->knob(DD::Image::kUseFrameRateKnobName.c_str());
+      if (pUserFrameRateKnob && (pUserFrameRateKnob->get_value() < 1.0)) {
+        DD::Image::Knob * pFrameRateKnob = op->knob(DD::Image::kFrameRateKnobName.c_str());
+        if (pFrameRateKnob) {
+          double d = pUserFrameRateKnob->get_value();
+          const float frameRate = (float)stage->GetFramesPerSecond();
+          pFrameRateKnob->set_value(frameRate);
+        }
+        else {
+          throw std::runtime_error("no \"" + DD::Image::kFrameRateKnobName + "\" knob");
+        }
+      }
+
+      if (start != end)
+        setKnobsAsAnimated(usdPrim, *op);
+      else
+        clearAnimation(usdPrim, *op);
+
+      setConstantTransformationAttributes(*op);
+      setCustomConstantAttributes(usdPrim, *op);
+      for (float time = start; time <= end; time += 1.0f) {
+        setTransformationAttributes(usdPrim, *op, time);
+        setCustomAnimationAttributes(usdPrim, *op, time);
+      }
+    }
+
+    void UsdSceneReaderBase::setKnobsAsAnimated(const UsdPrim& prim, DD::Image::Op& op) const
+    {
+      for (const auto& knobName : translationKnobs) {
+        setKnobIsAnimated(op, knobName, 3);
+      }
+
+      setCustomKnobsAsAnimated(prim, op);
+    }
+
+    void UsdSceneReaderBase::clearAnimation(const UsdPrim& prim, DD::Image::Op& op) const
+    {
+      for(const auto& knobName : translationKnobs) {
+        clearKnobAnimated(op, knobName);
+      }
+
+      clearCustomAnimation(prim, op);
+    }
+
+    void UsdSceneReaderBase::knobs(DD::Image::Knob_Callback cb)
+    {
+      Divider(cb, "USD Options");
+      static int index = 0;
+      _sceneGraphKnob = SceneGraph_knob(cb, &index, nullptr, DD::Image::kSceneGraphKnobName, "");
+      if (_sceneGraphKnob != nullptr) {
+        _sceneGraphKnob->set_flag(DD::Image::Knob::SAVE_MENU | DD::Image::Knob::EARLY_STORE | DD::Image::Knob::ALWAYS_SAVE | DD::Image::Knob::KNOB_CHANGED_RECURSIVE);
+        Tooltip(cb, "Usd primitive paths");
+      }
+    }
+
+    std::vector<DD::Image::Knob*> UsdSceneReaderBase::getFileDependentKnobs(DD::Image::SceneReader* /* reader */)
+    {
+      if (_sceneGraphKnob)
+        return { _sceneGraphKnob };
+      return {};
+    }
+
+    void UsdSceneReaderBase::setupSceneGraph() const
+    {
+      auto* sceneGraphKnobI = _sceneGraphKnob->sceneGraphKnob();
+      sceneGraphKnobI->enableListView();
+    }
+
+    DD::Image::SceneItem UsdSceneReaderBase::validateItems(DD::Image::SceneReader& reader, DD::Image::SceneItems& items)
+    {
+      auto item = std::find_if(items.cbegin(), items.cend(), [](const auto& prim) {
+        return prim.enabled;
+        });
+
+      if (item == items.cend()) {
+        _error = "USD file contains no supported data";
+        return DD::Image::SceneItem();
+      }
+      _error.clear();
+      return *item;
+    }
+  }
+}

--- a/UsdConverter/src/UsdUI.cpp
+++ b/UsdConverter/src/UsdUI.cpp
@@ -1,4 +1,4 @@
-// Copyright 2020 Foundry
+// Copyright 2021 Foundry
 //
 // Licensed under the Apache License, Version 2.0 (the "Apache License")
 // with the following modification; you may not use this file except in

--- a/UsdConverter/unit_tests/CMakeLists.txt
+++ b/UsdConverter/unit_tests/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2020 Foundry
+# Copyright 2021 Foundry
 #
 # Licensed under the Apache License, Version 2.0 (the "Apache License")
 # with the following modification; you may not use this file except in

--- a/UsdConverter/unit_tests/TestFixtures.cpp
+++ b/UsdConverter/unit_tests/TestFixtures.cpp
@@ -1,4 +1,4 @@
-// Copyright 2020 Foundry
+// Copyright 2021 Foundry
 //
 // Licensed under the Apache License, Version 2.0 (the "Apache License")
 // with the following modification; you may not use this file except in

--- a/UsdConverter/unit_tests/TestFixtures.h
+++ b/UsdConverter/unit_tests/TestFixtures.h
@@ -1,4 +1,4 @@
-// Copyright 2020 Foundry
+// Copyright 2021 Foundry
 //
 // Licensed under the Apache License, Version 2.0 (the "Apache License")
 // with the following modification; you may not use this file except in

--- a/UsdConverter/unit_tests/UsdAttrConverterTest.cpp
+++ b/UsdConverter/unit_tests/UsdAttrConverterTest.cpp
@@ -1,4 +1,4 @@
-// Copyright 2020 Foundry
+// Copyright 2021 Foundry
 //
 // Licensed under the Apache License, Version 2.0 (the "Apache License")
 // with the following modification; you may not use this file except in

--- a/UsdConverter/unit_tests/UsdGeoConverterTest.cpp
+++ b/UsdConverter/unit_tests/UsdGeoConverterTest.cpp
@@ -1,4 +1,4 @@
-// Copyright 2020 Foundry
+// Copyright 2021 Foundry
 //
 // Licensed under the Apache License, Version 2.0 (the "Apache License")
 // with the following modification; you may not use this file except in

--- a/UsdConverter/unit_tests/UsdGeoConverterTest.cpp
+++ b/UsdConverter/unit_tests/UsdGeoConverterTest.cpp
@@ -38,6 +38,7 @@
 #include <pxr/usd/usdGeom/mesh.h>
 #include <pxr/usd/usdGeom/pointInstancer.h>
 #include <pxr/usd/usdGeom/points.h>
+#include <pxr/usd/usdGeom/sphere.h>
 #include <pxr/usd/usdGeom/primvarsAPI.h>
 #include <pxr/usd/usdGeom/xformCache.h>
 #include <pxr/usd/usdGeom/xformCommonAPI.h>
@@ -46,6 +47,7 @@
 
 #include "TestFixtures.h"
 #include "UsdConverter/UsdGeoConverter.h"
+#include "UsdConverter/UsdUI.h"
 
 PXR_NAMESPACE_USING_DIRECTIVE
 
@@ -196,6 +198,12 @@ TEST_CASE("Prim conversions")
   SECTION("UsdGeomPointInstancer")
   {
     UsdGeomPointInstancer fromPrim = UsdGeomPointInstancer::Define(stage, path);
+    UsdGeomXformOp op = fromPrim.MakeMatrixXform();
+    GfMatrix4d transformMatrix(1, 0, 0, 0,
+                               0, 1, 0, 0,
+                               0, 0, 1, 0,
+                               2, 2, 2, 1);
+    op.Set(transformMatrix);
 
     UsdGeomMesh fromMesh;
     VtVec3fArray points;
@@ -245,8 +253,8 @@ TEST_CASE("Prim conversions")
     MemoryAllocator context;
     TestGeoOp geo;
     addUsdPrim<UsdGeomPointInstancer>(*geo.geometryList(), fromPrim, time);
-    // 1 for the usd point instance, 2 instances of polymesh
-    REQUIRE(geo.geometryList()->objects() == 3);
+    // 2 instances of polymesh
+    REQUIRE(geo.geometryList()->objects() == 2);
 
     GeoInfo& info = geo.geometryList()->object(1);
     CHECK_THAT(points,
@@ -271,6 +279,16 @@ TEST_CASE("Prim conversions")
                    *(info.get_group_attribute(Group_Vertices, kUVAttrName)
                          ->vector4_list),
                    2));
+
+    VtVec4fArray extectedTransform{{ 1.f,  0.f,  0.f, 0.f},
+                                   { 0.f,  1.f,  0.f, 0.f},
+                                   { 0.f,  0.f,  1.f, 0.f},
+                                   {22.f, 22.f, 22.f, 1.f} };
+    CHECK_THAT(extectedTransform,
+      ArraysOfVectorsEqual<decltype(extectedTransform)>(
+        *(info.get_group_attribute(Group_Object, kTransformAttrName)
+          ->vector4_list),
+        4));
   }
 }
 
@@ -295,4 +313,28 @@ TEST_CASE_METHOD(MemoryAllocator, "Add transforms")
       CHECK(expectedMatrix[c][r] == testResult[c][r]);
     }
   }
+}
+
+TEST_CASE("getPrimitiveData returns correct data")
+{
+  UsdStageRefPtr stage = UsdStage::CreateInMemory();
+  SdfPath path("/points1");
+  UsdGeomPoints points = UsdGeomPoints::Define(stage, path);
+  SdfPath cubePath("/cube1");
+  auto cube = UsdGeomCube::Define(stage, cubePath);
+  SdfPath meshPath("/mesh1");
+  auto mesh = UsdGeomMesh::Define(stage, meshPath);
+  SdfPath instancePath("/instancer1");
+  auto instancer = UsdGeomPointInstancer::Define(stage, instancePath);
+  SdfPath spherePath("/sphere1");
+  auto sphere = UsdGeomSphere::Define(stage, spherePath);
+
+  const SceneItems& data = getPrimitiveData(stage, supportedPrimTypes);
+  SceneItems expected;
+  expected.emplace_back("/points1", "Points");
+  expected.emplace_back("/cube1", "Cube");
+  expected.emplace_back("/mesh1", "Mesh");
+  expected.emplace_back("/instancer1", "PointInstancer");
+  expected.emplace_back("/sphere1", "Sphere", false);
+  CHECK(data == expected);
 }


### PR DESCRIPTION
This adds USD Light/Camera/Axis plugins for the Light, Camera, and Axis nodes in Nuke. The Light, Camera, and Axis nodes require an API change only available in Nuke 13.0v1 and above. The latest version of NukeUsdPlugins that works with Nuke12.2 will be tagged with Nuke12.2. 

The readme has also been updated with more detailed build instructions. 